### PR TITLE
MPI deadlocks with Cray-MPICH

### DIFF
--- a/source/exchange.for
+++ b/source/exchange.for
@@ -447,9 +447,9 @@
                  ta=2
                  call MPI_IRECV  (dom(ib)%recvb_m1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%iprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
-                 call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%iprev),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m1(1),ierr)
+                 call MPI_ISEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%iprev),tag,MPI_COMM_WORLD,dom(ib)%rq_m1(2),ierr)
               end if
 
            end if
@@ -474,10 +474,10 @@
                  ta=4
                  call MPI_IRECV  (dom(ib)%recvb_m2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m2(1),ierr)
 
-                 call MPI_SEND (dom(ib)%sendb_m2(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%jprev),tag,MPI_COMM_WORLD,ierr)
+                 call MPI_ISEND (dom(ib)%sendb_m2(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%jprev),tag,MPI_COMM_WORLD,dom(ib)%rq_m2(2),ierr)
               end if
 
            end if
@@ -502,9 +502,9 @@
                  ta=6
                  call MPI_IRECV  (dom(ib)%recvb_m3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%kprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m3,ierr)
-                 call MPI_SEND (dom(ib)%sendb_m3(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%kprev),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m3(1),ierr)
+                 call MPI_ISEND (dom(ib)%sendb_m3(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%kprev),tag,MPI_COMM_WORLD,dom(ib)%rq_m3(2),ierr)
 
               end if
 
@@ -532,9 +532,9 @@
                  ta=1
              call MPI_IRECV  (dom(ib)%recvb_p1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%inext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
-                 call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%inext),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p1(1),ierr)
+                 call MPI_ISEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%inext),tag,MPI_COMM_WORLD,dom(ib)%rq_p1(2),ierr)
     
               end if
 
@@ -560,9 +560,9 @@
                  ta=3
                  call MPI_IRECV  (dom(ib)%recvb_p2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jnext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p2,ierr)
-                 call MPI_SEND (dom(ib)%sendb_p2(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%jnext),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p2(1),ierr)
+                 call MPI_ISEND (dom(ib)%sendb_p2(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%jnext),tag,MPI_COMM_WORLD,dom(ib)%rq_p2(2),ierr)
 
               end if
 
@@ -588,9 +588,9 @@
                  ta=5
                  call MPI_IRECV  (dom(ib)%recvb_p3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%knext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p3,ierr)
-                 call MPI_SEND (dom(ib)%sendb_p3(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%knext),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p3(1),ierr)
+                 call MPI_ISEND (dom(ib)%sendb_p3(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%knext),tag,MPI_COMM_WORLD,dom(ib)%rq_p3(2),ierr)
 
               end if
 
@@ -620,9 +620,10 @@
                  tag=7*10**5+dom(ib)%corprev1
                  call MPI_IRECV  (dom(ib)%rc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),dom(ib)%tg(8),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1m,ierr)
-                 call MPI_SEND (dom(ib)%sc1m(1),(pl+1)**3,MPI_FLT,
-     &dom_ad(dom(ib)%corprev1),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1m(1),ierr)
+                 call MPI_ISEND (dom(ib)%sc1m(1),(pl+1)**3,MPI_FLT,
+     &dom_ad(dom(ib)%corprev1),tag,MPI_COMM_WORLD,dom(ib)%rq_c1m(2),
+     &ierr)
 
               end if
            end if
@@ -647,9 +648,10 @@
                  tag=9*10**5+dom(ib)%corprev2
                  call MPI_IRECV  (dom(ib)%rc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),dom(ib)%tg(10),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2m,ierr)
-                 call MPI_SEND (dom(ib)%sc2m(1),(pl+1)**3,MPI_FLT,
-     &dom_ad(dom(ib)%corprev2),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2m(1),ierr)
+                 call MPI_ISEND (dom(ib)%sc2m(1),(pl+1)**3,MPI_FLT,
+     &dom_ad(dom(ib)%corprev2),tag,MPI_COMM_WORLD,dom(ib)%rq_c2m(2),
+     &ierr)
 
               end if
            end if
@@ -674,9 +676,10 @@
                  tag=11*10**5+dom(ib)%corprev3
                  call MPI_IRECV  (dom(ib)%rc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),dom(ib)%tg(12),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3m,ierr)
-                 call MPI_SEND (dom(ib)%sc3m(1),(pl+1)**3,MPI_FLT,
-     &dom_ad(dom(ib)%corprev3),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3m(1),ierr)
+                 call MPI_ISEND (dom(ib)%sc3m(1),(pl+1)**3,MPI_FLT,
+     &dom_ad(dom(ib)%corprev3),tag,MPI_COMM_WORLD,dom(ib)%rq_c3m(2),
+     &ierr)
 
               end if
            end if
@@ -701,9 +704,10 @@
                  tag=13*10**5+dom(ib)%corprev4
                  call MPI_IRECV  (dom(ib)%rc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),dom(ib)%tg(14),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4m,ierr)
-                 call MPI_SEND (dom(ib)%sc4m(1),(pl+1)**3,MPI_FLT,
-     &dom_ad(dom(ib)%corprev4),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4m(1),ierr)
+                 call MPI_ISEND (dom(ib)%sc4m(1),(pl+1)**3,MPI_FLT,
+     &dom_ad(dom(ib)%corprev4),tag,MPI_COMM_WORLD,dom(ib)%rq_c4m(2),
+     &ierr)
 
               end if
            end if
@@ -728,9 +732,10 @@
                  tag=8*10**5+dom(ib)%cornext1
                  call MPI_IRECV  (dom(ib)%rc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),dom(ib)%tg(7),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1p,ierr)
-                 call MPI_SEND (dom(ib)%sc1p(1),(pl+1)**3,MPI_FLT,
-     &dom_ad(dom(ib)%cornext1),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1p(1),ierr)
+                 call MPI_ISEND (dom(ib)%sc1p(1),(pl+1)**3,MPI_FLT,
+     &dom_ad(dom(ib)%cornext1),tag,MPI_COMM_WORLD,dom(ib)%rq_c1p(2),
+     &ierr)
 
               end if
            end if
@@ -755,9 +760,10 @@
                  tag=10*10**5+dom(ib)%cornext2
                  call MPI_IRECV  (dom(ib)%rc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),dom(ib)%tg(9),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2p,ierr)
-                 call MPI_SEND (dom(ib)%sc2p(1),(pl+1)**3,MPI_FLT,
-     &dom_ad(dom(ib)%cornext2),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2p(1),ierr)
+                 call MPI_ISEND (dom(ib)%sc2p(1),(pl+1)**3,MPI_FLT,
+     &dom_ad(dom(ib)%cornext2),tag,MPI_COMM_WORLD,dom(ib)%rq_c2p(2),
+     &ierr)
 
               end if
            end if
@@ -782,9 +788,10 @@
                  tag=12*10**5+dom(ib)%cornext3
                  call MPI_IRECV  (dom(ib)%rc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),dom(ib)%tg(11),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3p,ierr)
-                 call MPI_SEND (dom(ib)%sc3p(1),(pl+1)**3,MPI_FLT,
-     &dom_ad(dom(ib)%cornext3),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3p(1),ierr)
+                 call MPI_ISEND (dom(ib)%sc3p(1),(pl+1)**3,MPI_FLT,
+     &dom_ad(dom(ib)%cornext3),tag,MPI_COMM_WORLD,dom(ib)%rq_c3p(2),
+     &ierr)
 
               end if
            end if
@@ -809,9 +816,10 @@
                  tag=14*10**5+dom(ib)%cornext4
                  call MPI_IRECV  (dom(ib)%rc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),dom(ib)%tg(13),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4p,ierr)
-                 call MPI_SEND (dom(ib)%sc4p(1),(pl+1)**3,MPI_FLT,
-     &dom_ad(dom(ib)%cornext4),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4p(1),ierr)
+                 call MPI_ISEND (dom(ib)%sc4p(1),(pl+1)**3,MPI_FLT,
+     &dom_ad(dom(ib)%cornext4),tag,MPI_COMM_WORLD,dom(ib)%rq_c4p(2),
+     &ierr)
 
               end if
            end if
@@ -837,9 +845,10 @@
                  tag=15*10**5+dom(ib)%edgprev1
                  call MPI_IRECV  (dom(ib)%re1m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),dom(ib)%tg(16),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1m,ierr)
-                 call MPI_SEND (dom(ib)%se1m(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%edgprev1),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1m(1),ierr)
+                 call MPI_ISEND (dom(ib)%se1m(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%edgprev1),tag,MPI_COMM_WORLD,dom(ib)%rq_e1m(2),
+     &ierr)
 
               end if
            end if
@@ -865,9 +874,10 @@
                  tag=17*10**5+dom(ib)%edgprev2
                call MPI_IRECV  (dom(ib)%re2m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),dom(ib)%tg(18),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2m,ierr)
-                 call MPI_SEND (dom(ib)%se2m(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%edgprev2),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2m(1),ierr)
+                 call MPI_ISEND (dom(ib)%se2m(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%edgprev2),tag,MPI_COMM_WORLD,dom(ib)%rq_e2m(2),
+     &ierr)
   
               end if
            end if
@@ -893,9 +903,10 @@
                  tag=19*10**5+dom(ib)%edgprev3
                  call MPI_IRECV  (dom(ib)%re3m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),dom(ib)%tg(20),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3m,ierr)
-                 call MPI_SEND (dom(ib)%se3m(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%edgprev3),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3m(1),ierr)
+                 call MPI_ISEND (dom(ib)%se3m(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%edgprev3),tag,MPI_COMM_WORLD,dom(ib)%rq_e3m(2),
+     &ierr)
 
               end if
            end if
@@ -921,9 +932,10 @@
                  tag=21*10**5+dom(ib)%edgprev4
                  call MPI_IRECV  (dom(ib)%re4m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),dom(ib)%tg(22),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4m,ierr)
-                 call MPI_SEND (dom(ib)%se4m(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%edgprev4),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4m(1),ierr)
+                 call MPI_ISEND (dom(ib)%se4m(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%edgprev4),tag,MPI_COMM_WORLD,dom(ib)%rq_e4m(2),
+     &ierr)
 
               end if
            end if
@@ -949,9 +961,10 @@
                  tag=23*10**5+dom(ib)%edgprev5
                  call MPI_IRECV  (dom(ib)%re5m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),dom(ib)%tg(24),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5m,ierr)
-                 call MPI_SEND (dom(ib)%se5m(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%edgprev5),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5m(1),ierr)
+                 call MPI_ISEND (dom(ib)%se5m(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%edgprev5),tag,MPI_COMM_WORLD,dom(ib)%rq_e5m(2),
+     &ierr)
 
               end if
            end if
@@ -977,9 +990,10 @@
                  tag=25*10**5+dom(ib)%edgprev6
                  call MPI_IRECV  (dom(ib)%re6m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),dom(ib)%tg(26),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6m,ierr)
-                 call MPI_SEND (dom(ib)%se6m(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%edgprev6),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6m(1),ierr)
+                 call MPI_ISEND (dom(ib)%se6m(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%edgprev6),tag,MPI_COMM_WORLD,dom(ib)%rq_e6m(2),
+     &ierr)
 
               end if
            end if
@@ -1005,9 +1019,10 @@
                  tag=16*10**5+dom(ib)%edgnext1
                  call MPI_IRECV  (dom(ib)%re1p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),dom(ib)%tg(15),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1p,ierr)
-                 call MPI_SEND (dom(ib)%se1p(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%edgnext1),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1p(1),ierr)
+                 call MPI_ISEND (dom(ib)%se1p(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%edgnext1),tag,MPI_COMM_WORLD,dom(ib)%rq_e1p(2),
+     &ierr)
 
               end if
            end if
@@ -1033,9 +1048,10 @@
                  tag=18*10**5+dom(ib)%edgnext2
                  call MPI_IRECV  (dom(ib)%re2p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),dom(ib)%tg(17),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2p,ierr)
-                 call MPI_SEND (dom(ib)%se2p(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%edgnext2),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2p(1),ierr)
+                 call MPI_ISEND (dom(ib)%se2p(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%edgnext2),tag,MPI_COMM_WORLD,dom(ib)%rq_e2p(2),
+     &ierr)
 
               end if
            end if
@@ -1061,9 +1077,10 @@
                  tag=20*10**5+dom(ib)%edgnext3
                  call MPI_IRECV  (dom(ib)%re3p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),dom(ib)%tg(19),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3p,ierr)
-                 call MPI_SEND (dom(ib)%se3p(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%edgnext3),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3p(1),ierr)
+                 call MPI_ISEND (dom(ib)%se3p(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%edgnext3),tag,MPI_COMM_WORLD,dom(ib)%rq_e3p(2),
+     &ierr)
 
               end if
            end if
@@ -1089,9 +1106,10 @@
                  tag=22*10**5+dom(ib)%edgnext4
                  call MPI_IRECV  (dom(ib)%re4p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),dom(ib)%tg(21),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4p,ierr)
-                 call MPI_SEND (dom(ib)%se4p(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%edgnext4),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4p(1),ierr)
+                 call MPI_ISEND (dom(ib)%se4p(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%edgnext4),tag,MPI_COMM_WORLD,dom(ib)%rq_e4p(2),
+     &ierr)
 
               end if
            end if
@@ -1117,9 +1135,10 @@
                  tag=24*10**5+dom(ib)%edgnext5
                  call MPI_IRECV  (dom(ib)%re5p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),dom(ib)%tg(23),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5p,ierr)
-                 call MPI_SEND (dom(ib)%se5p(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%edgnext5),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5p(1),ierr)
+                 call MPI_ISEND (dom(ib)%se5p(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%edgnext5),tag,MPI_COMM_WORLD,dom(ib)%rq_e5p(2),
+     &ierr)
 
               end if
            end if
@@ -1145,9 +1164,10 @@
                  tag=26*10**5+dom(ib)%edgnext6
                  call MPI_IRECV  (dom(ib)%re6p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),dom(ib)%tg(25),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6p,ierr)
-                 call MPI_SEND (dom(ib)%se6p(1),tsend,MPI_FLT,
-     &dom_ad(dom(ib)%edgnext6),tag,MPI_COMM_WORLD,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6p(1),ierr)
+                 call MPI_ISEND (dom(ib)%se6p(1),tsend,MPI_FLT,
+     &dom_ad(dom(ib)%edgnext6),tag,MPI_COMM_WORLD,dom(ib)%rq_e6p(2),
+     &ierr)
 
               end if
            end if
@@ -1271,7 +1291,8 @@
         if (dom(ib)%corprev1.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%corprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_c1m,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do pl3=0,pl
                  ijk=pl1*pll+pl2*(pl+1)+pl3+1
@@ -1285,7 +1306,8 @@
         if (dom(ib)%corprev2.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%corprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_c2m,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do pl3=0,pl
                  ijk=pl1*pll+pl2*(pl+1)+pl3+1
@@ -1299,7 +1321,8 @@
         if (dom(ib)%corprev3.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%corprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_c3m,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do pl3=0,pl
                  ijk=pl1*pll+pl2*(pl+1)+pl3+1
@@ -1313,7 +1336,8 @@
         if (dom(ib)%corprev4.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%corprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_c4m,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do pl3=0,pl
                  ijk=pl1*pll+pl2*(pl+1)+pl3+1
@@ -1327,7 +1351,8 @@
         if (dom(ib)%cornext1.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%cornext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_c1p,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do pl3=0,pl
                  ijk=pl1*pll+pl2*(pl+1)+pl3+1
@@ -1341,7 +1366,8 @@
         if (dom(ib)%cornext2.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%cornext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_c2p,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do pl3=0,pl
                  ijk=pl1*pll+pl2*(pl+1)+pl3+1
@@ -1355,7 +1381,8 @@
         if (dom(ib)%cornext3.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%cornext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_c3p,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do pl3=0,pl
                  ijk=pl1*pll+pl2*(pl+1)+pl3+1
@@ -1369,7 +1396,8 @@
         if (dom(ib)%cornext4.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%cornext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_c4p,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do pl3=0,pl
                  ijk=pl1*pll+pl2*(pl+1)+pl3+1
@@ -1383,7 +1411,8 @@
         if (dom(ib)%edgprev1.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%edgprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_e1m,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do nn=jspr,jepr
                  ijk=(nn-1)*pll+pl1*(pl+1)+pl2+1
@@ -1397,7 +1426,8 @@
         if (dom(ib)%edgprev2.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%edgprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_e2m,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do nn=ispr,iepr
                  ijk=(nn-1)*pll+pl1*(pl+1)+pl2+1
@@ -1411,7 +1441,8 @@
         if (dom(ib)%edgprev3.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%edgprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_e3m,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do nn=jspr,jepr
                  ijk=(nn-1)*pll+pl1*(pl+1)+pl2+1
@@ -1425,7 +1456,8 @@
         if (dom(ib)%edgprev4.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%edgprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_e4m,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do nn=ispr,iepr
                  ijk=(nn-1)*pll+pl1*(pl+1)+pl2+1
@@ -1439,7 +1471,8 @@
         if (dom(ib)%edgprev5.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%edgprev5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_e5m,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do nn=kspr,kepr
                  ijk=(nn-1)*pll+pl1*(pl+1)+pl2+1
@@ -1453,7 +1486,8 @@
         if (dom(ib)%edgprev6.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%edgprev6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_e6m,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do nn=kspr,kepr
                  ijk=(nn-1)*pll+pl1*(pl+1)+pl2+1
@@ -1467,7 +1501,8 @@
         if (dom(ib)%edgnext1.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%edgnext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_e1p,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do nn=jspr,jepr
                  ijk=(nn-1)*pll+pl1*(pl+1)+pl2+1
@@ -1481,7 +1516,8 @@
         if (dom(ib)%edgnext2.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%edgnext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_e2p,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do nn=ispr,iepr
                  ijk=(nn-1)*pll+pl1*(pl+1)+pl2+1
@@ -1495,7 +1531,8 @@
         if (dom(ib)%edgnext3.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%edgnext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_e3p,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do nn=jspr,jepr
                  ijk=(nn-1)*pll+pl1*(pl+1)+pl2+1
@@ -1509,7 +1546,8 @@
         if (dom(ib)%edgnext4.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%edgnext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_e4p,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do nn=ispr,iepr
                  ijk=(nn-1)*pll+pl1*(pl+1)+pl2+1
@@ -1523,7 +1561,8 @@
         if (dom(ib)%edgnext5.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%edgnext5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_e5p,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do nn=kspr,kepr
                  ijk=(nn-1)*pll+pl1*(pl+1)+pl2+1
@@ -1537,7 +1576,8 @@
         if (dom(ib)%edgnext6.ge.0) then
            if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%edgnext6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAITALL(2,dom(ib)%rq_e6p,
+     &MPI_STATUSES_IGNORE,ierr)
               end if
               do pl1=0,pl; do pl2=0,pl; do nn=kspr,kepr
                  ijk=(nn-1)*pll+pl1*(pl+1)+pl2+1
@@ -1557,7 +1597,8 @@
               if (dom(ib)%iprev.ge.0)  then
               if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%iprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%iprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAITALL(2,dom(ib)%rq_m1,
+     &MPI_STATUSES_IGNORE,ierr)
                  end if
                  do k=1,nk; do j=1,nj; ijk=(k-1)*nj+j
                     dom(ib)%stfcinf(1,ly+1,ijk)=dom(ib) % recvb_m1(ijk)
@@ -1571,7 +1612,8 @@
               if (dom(ib)%jprev.ge.0)  then
               if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%jprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAITALL(2,dom(ib)%rq_m2,
+     &MPI_STATUSES_IGNORE,ierr)
                  end if
                  do k=1,nk; do i=1,ni; ijk=(k-1)*ni+i
                     dom(ib)%stfcinf(3,ly+1,ijk)=dom(ib) % recvb_m2(ijk)
@@ -1585,7 +1627,8 @@
               if (dom(ib)%kprev.ge.0)  then
               if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%kprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%kprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAITALL(2,dom(ib)%rq_m3,
+     &MPI_STATUSES_IGNORE,ierr)
                  end if
                  do i=1,ni; do j=1,nj; ijk=(i-1)*nj+j
                     dom(ib)%stfcinf(5,ly+1,ijk)=dom(ib) % recvb_m3(ijk)
@@ -1602,7 +1645,8 @@
               if (dom(ib)%inext.ge.0)  then
               if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%inext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%inext)) then
-                    call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAITALL(2,dom(ib)%rq_p1,
+     &MPI_STATUSES_IGNORE,ierr)
                  end if
                  do k=1,nk; do j=1,nj; ijk=(k-1)*nj+j
                     dom(ib)%stfcinf(2,ly+1,ijk)=dom(ib) % recvb_p1(ijk)
@@ -1616,7 +1660,8 @@
               if (dom(ib)%jnext.ge.0)  then
               if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%jnext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jnext)) then
-                    call MPI_WAIT(dom(ib)%rq_p2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAITALL(2,dom(ib)%rq_p2,
+     &MPI_STATUSES_IGNORE,ierr)
                  end if
                  do k=1,nk; do i=1,ni; ijk=(k-1)*ni+i
                     dom(ib)%stfcinf(4,ly+1,ijk)=dom(ib) % recvb_p2(ijk)
@@ -1630,7 +1675,8 @@
               if (dom(ib)%knext.ge.0)  then
               if(rdiv(dom_id(ib)).eq.rdiv(dom(ib)%knext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%knext)) then
-                    call MPI_WAIT(dom(ib)%rq_p3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAITALL(2,dom(ib)%rq_p3,
+     &MPI_STATUSES_IGNORE,ierr)
                  end if
                  do i=1,ni; do j=1,nj; ijk=(i-1)*nj+j
                     dom(ib)%stfcinf(6,ly+1,ijk)=dom(ib) % recvb_p3(ijk)

--- a/source/exchange_bc.for
+++ b/source/exchange_bc.for
@@ -139,7 +139,7 @@
                     tag1=1*10**8+my_cor    *10**4+dom_id(ib)
                     tag2=2*10**8+dom_id(ib)*10**4+my_cor
                     call MPI_IRECV  (dom(ib)%recvb_m1(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
+     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m1(1),ierr)
                     call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag1,MPI_COMM_WORLD,ierr)
                  end if
@@ -171,7 +171,7 @@
                     tag3=2*10**8+my_cor    *10**4+dom_id(ib)
                     tag4=1*10**8+dom_id(ib)*10**4+my_cor
                     call MPI_IRECV  (dom(ib)%recvb_p1(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
+     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p1(1),ierr)
                     call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag3,MPI_COMM_WORLD,ierr)
 
@@ -204,7 +204,7 @@
                     tag1=3*10**8+my_cor    *10**4+dom_id(ib)
                     tag2=4*10**8+dom_id(ib)*10**4+my_cor
                     call MPI_IRECV  (dom(ib)%recvb_m2(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m2,ierr)
+     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m2(1),ierr)
                     call MPI_SEND (dom(ib)%sendb_m2(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag1,MPI_COMM_WORLD,ierr)
 
@@ -237,7 +237,7 @@
                     tag3=4*10**8+my_cor    *10**4+dom_id(ib)
                     tag4=3*10**8+dom_id(ib)*10**4+my_cor
                     call MPI_IRECV  (dom(ib)%recvb_p2(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p2,ierr)
+     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p2(1),ierr)
                     call MPI_SEND (dom(ib)%sendb_p2(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag3,MPI_COMM_WORLD,ierr)
 
@@ -270,7 +270,7 @@
                     tag1=5*10**8+my_cor    *10**4+dom_id(ib)
                     tag2=6*10**8+dom_id(ib)*10**4+my_cor
                     call MPI_IRECV  (dom(ib)%recvb_m3(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m3,ierr)
+     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m3(1),ierr)
                     call MPI_SEND (dom(ib)%sendb_m3(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag1,MPI_COMM_WORLD,ierr)
 
@@ -303,7 +303,7 @@
                     tag3=6*10**8+my_cor    *10**4+dom_id(ib)
                     tag4=5*10**8+dom_id(ib)*10**4+my_cor
                     call MPI_IRECV  (dom(ib)%recvb_p3(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p3,ierr)
+     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p3(1),ierr)
                     call MPI_SEND (dom(ib)%sendb_p3(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag3,MPI_COMM_WORLD,ierr)
 
@@ -419,7 +419,7 @@
      & dom(ib)%iprev.lt.0 .and. dom(ib)%inext.ge.0) then
               my_cor=dom(ib)%per_ip
               if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_m1(1),MPI_STATUS_IGNORE,ierr)
               end if
               rbuf => dom(ib) % recvb_m1
               do k=1,dom(ib)%ttc_k; do j=1,dom(ib)%ttc_j
@@ -434,7 +434,7 @@
      & dom(ib)%inext.lt.0 .and. dom(ib)%iprev.ge.0) then
               my_cor=dom(ib)%per_in
               if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_p1(1),MPI_STATUS_IGNORE,ierr)
               end if
               rbuf => dom(ib) % recvb_p1
               do k=1,dom(ib)%ttc_k; do j=1,dom(ib)%ttc_j
@@ -449,7 +449,7 @@
      & dom(ib)%jprev.lt.0 .and. dom(ib)%jnext.ge.0) then
               my_cor=dom(ib)%per_jp
               if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_m2,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_m2(1),MPI_STATUS_IGNORE,ierr)
               end if
               rbuf => dom(ib) % recvb_m2
               do k=1,dom(ib)%ttc_k; do i=1,dom(ib)%ttc_i
@@ -464,7 +464,7 @@
      & dom(ib)%jnext.lt.0 .and. dom(ib)%jprev.ge.0) then
               my_cor=dom(ib)%per_jn
               if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_p2,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_p2(1),MPI_STATUS_IGNORE,ierr)
               end if
               rbuf => dom(ib) % recvb_p2
               do k=1,dom(ib)%ttc_k; do i=1,dom(ib)%ttc_i
@@ -479,7 +479,7 @@
      & dom(ib)%kprev.lt.0 .and. dom(ib)%knext.ge.0) then
               my_cor=dom(ib)%per_kp
               if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_m3,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_m3(1),MPI_STATUS_IGNORE,ierr)
               end if
               rbuf => dom(ib) % recvb_m3
               do j=1,dom(ib)%ttc_j; do i=1,dom(ib)%ttc_i
@@ -494,7 +494,7 @@
      & dom(ib)%knext.lt.0 .and. dom(ib)%kprev.ge.0) then
               my_cor=dom(ib)%per_kn 
               if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_p3,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_p3(1),MPI_STATUS_IGNORE,ierr)
               end if
               rbuf => dom(ib) % recvb_p3
               do j=1,dom(ib)%ttc_j; do i=1,dom(ib)%ttc_i

--- a/source/exchange_bcphi.for
+++ b/source/exchange_bcphi.for
@@ -61,7 +61,7 @@
                     tag1=1*10**8+my_cor    *10**4+dom_id(ib)
                     tag2=2*10**8+dom_id(ib)*10**4+my_cor
                     call MPI_IRECV  (dom(ib)%recvb_m1(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
+     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m1(1),ierr)
                     call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag1,MPI_COMM_WORLD,ierr)
 
@@ -94,7 +94,7 @@
                     tag3=2*10**8+my_cor    *10**4+dom_id(ib)
                     tag4=1*10**8+dom_id(ib)*10**4+my_cor
                     call MPI_IRECV  (dom(ib)%recvb_p1(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
+     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p1(1),ierr)
                     call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag3,MPI_COMM_WORLD,ierr)
 
@@ -127,7 +127,7 @@
                     tag1=3*10**8+my_cor    *10**4+dom_id(ib)
                     tag2=4*10**8+dom_id(ib)*10**4+my_cor
                     call MPI_IRECV  (dom(ib)%recvb_m2(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m2,ierr)
+     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m2(1),ierr)
                     call MPI_SEND (dom(ib)%sendb_m2(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag1,MPI_COMM_WORLD,ierr)
 
@@ -160,7 +160,7 @@
                     tag3=4*10**8+my_cor    *10**4+dom_id(ib)
                     tag4=3*10**8+dom_id(ib)*10**4+my_cor
                     call MPI_IRECV  (dom(ib)%recvb_p2(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p2,ierr)
+     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p2(1),ierr)
                     call MPI_SEND (dom(ib)%sendb_p2(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag3,MPI_COMM_WORLD,ierr)
 
@@ -193,7 +193,7 @@
                     tag1=5*10**8+my_cor    *10**4+dom_id(ib)
                     tag2=6*10**8+dom_id(ib)*10**4+my_cor
                     call MPI_IRECV  (dom(ib)%recvb_m3(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m3,ierr)
+     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m3(1),ierr)
                     call MPI_SEND (dom(ib)%sendb_m3(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag1,MPI_COMM_WORLD,ierr)
 
@@ -226,7 +226,7 @@
                     tag3=6*10**8+my_cor    *10**4+dom_id(ib)
                     tag4=5*10**8+dom_id(ib)*10**4+my_cor
                     call MPI_IRECV  (dom(ib)%recvb_p3(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p3,ierr)
+     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p3(1),ierr)
                     call MPI_SEND (dom(ib)%sendb_p3(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag3,MPI_COMM_WORLD,ierr)
 
@@ -259,7 +259,7 @@
      & dom(ib)%iprev.lt.0 .and. dom(ib)%inext.ge.0) then
               my_cor=dom(ib)%per_ip
               if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_m1(1),MPI_STATUS_IGNORE,ierr)
               end if
               rbuf => dom(ib) % recvb_m1
               do k=1,dom(ib)%ttc_k; do j=1,dom(ib)%ttc_j
@@ -274,7 +274,7 @@
      & dom(ib)%inext.lt.0 .and. dom(ib)%iprev.ge.0) then
               my_cor=dom(ib)%per_in
               if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_p1(1),MPI_STATUS_IGNORE,ierr)
               end if
               rbuf => dom(ib) % recvb_p1
               do k=1,dom(ib)%ttc_k; do j=1,dom(ib)%ttc_j
@@ -289,7 +289,7 @@
      & dom(ib)%jprev.lt.0 .and. dom(ib)%jnext.ge.0) then
               my_cor=dom(ib)%per_jp
               if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_m2,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_m2(1),MPI_STATUS_IGNORE,ierr)
               end if
               rbuf => dom(ib) % recvb_m2
               do k=1,dom(ib)%ttc_k; do i=1,dom(ib)%ttc_i
@@ -304,7 +304,7 @@
      & dom(ib)%jnext.lt.0 .and. dom(ib)%jprev.ge.0) then
               my_cor=dom(ib)%per_jn
               if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_p2,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_p2(1),MPI_STATUS_IGNORE,ierr)
               end if
               rbuf => dom(ib) % recvb_p2
               do k=1,dom(ib)%ttc_k; do i=1,dom(ib)%ttc_i
@@ -319,7 +319,7 @@
      & dom(ib)%kprev.lt.0 .and. dom(ib)%knext.ge.0) then
               my_cor=dom(ib)%per_kp
               if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_m3,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_m3(1),MPI_STATUS_IGNORE,ierr)
               end if
               rbuf => dom(ib) % recvb_m3
               do j=1,dom(ib)%ttc_j; do i=1,dom(ib)%ttc_i
@@ -334,7 +334,7 @@
      & dom(ib)%knext.lt.0 .and. dom(ib)%kprev.ge.0) then
               my_cor=dom(ib)%per_kn 
               if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_p3,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_p3(1),MPI_STATUS_IGNORE,ierr)
               end if
               rbuf => dom(ib) % recvb_p3
               do j=1,dom(ib)%ttc_j; do i=1,dom(ib)%ttc_i

--- a/source/exchange_phi.for
+++ b/source/exchange_phi.for
@@ -340,7 +340,7 @@
                  ta=2
                  call MPI_IRECV  (dom(ib)%recvb_m1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%iprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%iprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -376,7 +376,7 @@
                  ta=4
                  call MPI_IRECV  (dom(ib)%recvb_m2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m2(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m2(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%jprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -412,7 +412,7 @@
                  ta=6
                  call MPI_IRECV  (dom(ib)%recvb_m3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%kprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m3,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m3(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m3(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%kprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -450,7 +450,7 @@
                  ta=1
                  call MPI_IRECV  (dom(ib)%recvb_p1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%inext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%inext),tag,MPI_COMM_WORLD,ierr)
 
@@ -486,7 +486,7 @@
                  ta=3
                  call MPI_IRECV  (dom(ib)%recvb_p2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jnext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p2(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p2(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%jnext),tag,MPI_COMM_WORLD,ierr)
 
@@ -522,7 +522,7 @@
                  ta=5
                  call MPI_IRECV  (dom(ib)%recvb_p3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%knext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p3,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p3(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p3(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%knext),tag,MPI_COMM_WORLD,ierr)
 
@@ -562,7 +562,7 @@
                  tag=7*10**5+dom(ib)%corprev1
                call MPI_IRECV  (dom(ib)%rc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),dom(ib)%tg(8),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1m(1),ierr)
                  call MPI_SEND (dom(ib)%sc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),tag,MPI_COMM_WORLD,ierr)
   
@@ -597,7 +597,7 @@
                  tag=9*10**5+dom(ib)%corprev2
                  call MPI_IRECV  (dom(ib)%rc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),dom(ib)%tg(10),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2m(1),ierr)
                  call MPI_SEND (dom(ib)%sc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -632,7 +632,7 @@
                  tag=11*10**5+dom(ib)%corprev3
                  call MPI_IRECV  (dom(ib)%rc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),dom(ib)%tg(12),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3m(1),ierr)
                  call MPI_SEND (dom(ib)%sc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -667,7 +667,7 @@
                  tag=13*10**5+dom(ib)%corprev4
                  call MPI_IRECV  (dom(ib)%rc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),dom(ib)%tg(14),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4m(1),ierr)
                  call MPI_SEND (dom(ib)%sc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -702,7 +702,7 @@
                  tag=8*10**5+dom(ib)%cornext1
                  call MPI_IRECV  (dom(ib)%rc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),dom(ib)%tg(7),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1p(1),ierr)
                  call MPI_SEND (dom(ib)%sc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -737,7 +737,7 @@
                  tag=10*10**5+dom(ib)%cornext2
                  call MPI_IRECV  (dom(ib)%rc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),dom(ib)%tg(9),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2p(1),ierr)
                  call MPI_SEND (dom(ib)%sc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),tag,MPI_COMM_WORLD,ierr)
 
@@ -772,7 +772,7 @@
                  tag=12*10**5+dom(ib)%cornext3
                  call MPI_IRECV  (dom(ib)%rc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),dom(ib)%tg(11),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3p(1),ierr)
                  call MPI_SEND (dom(ib)%sc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),tag,MPI_COMM_WORLD,ierr)
 
@@ -807,7 +807,7 @@
                  tag=14*10**5+dom(ib)%cornext4
                  call MPI_IRECV  (dom(ib)%rc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),dom(ib)%tg(13),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4p(1),ierr)
                  call MPI_SEND (dom(ib)%sc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -844,7 +844,7 @@
                  tag=15*10**5+dom(ib)%edgprev1
                  call MPI_IRECV  (dom(ib)%re1m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),dom(ib)%tg(16),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1m(1),ierr)
                  call MPI_SEND (dom(ib)%se1m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),tag,MPI_COMM_WORLD,ierr)
 
@@ -881,7 +881,7 @@
                  tag=17*10**5+dom(ib)%edgprev2
                  call MPI_IRECV  (dom(ib)%re2m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),dom(ib)%tg(18),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2m(1),ierr)
                  call MPI_SEND (dom(ib)%se2m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -918,7 +918,7 @@
                  tag=19*10**5+dom(ib)%edgprev3
                  call MPI_IRECV  (dom(ib)%re3m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),dom(ib)%tg(20),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3m(1),ierr)
                  call MPI_SEND (dom(ib)%se3m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -955,7 +955,7 @@
                  tag=21*10**5+dom(ib)%edgprev4
                  call MPI_IRECV  (dom(ib)%re4m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),dom(ib)%tg(22),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4m(1),ierr)
                  call MPI_SEND (dom(ib)%se4m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -992,7 +992,7 @@
                  tag=23*10**5+dom(ib)%edgprev5
                  call MPI_IRECV  (dom(ib)%re5m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),dom(ib)%tg(24),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5m(1),ierr)
                  call MPI_SEND (dom(ib)%se5m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1029,7 +1029,7 @@
                  tag=25*10**5+dom(ib)%edgprev6
                  call MPI_IRECV  (dom(ib)%re6m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),dom(ib)%tg(26),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6m(1),ierr)
                  call MPI_SEND (dom(ib)%se6m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1066,7 +1066,7 @@
                  tag=16*10**5+dom(ib)%edgnext1
                  call MPI_IRECV  (dom(ib)%re1p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),dom(ib)%tg(15),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1p(1),ierr)
                  call MPI_SEND (dom(ib)%se1p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -1103,7 +1103,7 @@
                  tag=18*10**5+dom(ib)%edgnext2
                  call MPI_IRECV  (dom(ib)%re2p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),dom(ib)%tg(17),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2p(1),ierr)
                  call MPI_SEND (dom(ib)%se2p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),tag,MPI_COMM_WORLD,ierr)
 
@@ -1140,7 +1140,7 @@
                  tag=20*10**5+dom(ib)%edgnext3
                  call MPI_IRECV  (dom(ib)%re3p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),dom(ib)%tg(19),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3p(1),ierr)
                  call MPI_SEND (dom(ib)%se3p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),tag,MPI_COMM_WORLD,ierr)
 
@@ -1177,7 +1177,7 @@
                  tag=22*10**5+dom(ib)%edgnext4
                  call MPI_IRECV  (dom(ib)%re4p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),dom(ib)%tg(21),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4p(1),ierr)
                  call MPI_SEND (dom(ib)%se4p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1214,7 +1214,7 @@
                  tag=24*10**5+dom(ib)%edgnext5
                  call MPI_IRECV  (dom(ib)%re5p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),dom(ib)%tg(23),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5p(1),ierr)
                  call MPI_SEND (dom(ib)%se5p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1251,7 +1251,7 @@
                  tag=26*10**5+dom(ib)%edgnext6
                  call MPI_IRECV  (dom(ib)%re6p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),dom(ib)%tg(25),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6p(1),ierr)
                  call MPI_SEND (dom(ib)%se6p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1297,7 +1297,7 @@
         if (dom(ib)%corprev1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c1m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1312,7 +1312,7 @@
         if (dom(ib)%corprev2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c2m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1327,7 +1327,7 @@
         if (dom(ib)%corprev3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c3m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1342,7 +1342,7 @@
         if (dom(ib)%corprev4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c4m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1357,7 +1357,7 @@
         if (dom(ib)%cornext1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c1p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1372,7 +1372,7 @@
         if (dom(ib)%cornext2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c2p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1387,7 +1387,7 @@
         if (dom(ib)%cornext3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c3p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1402,7 +1402,7 @@
         if (dom(ib)%cornext4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c4p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1417,7 +1417,7 @@
         if (dom(ib)%edgprev1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e1m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1432,7 +1432,7 @@
         if (dom(ib)%edgprev2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e2m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1447,7 +1447,7 @@
         if (dom(ib)%edgprev3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e3m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1462,7 +1462,7 @@
         if (dom(ib)%edgprev4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e4m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1477,7 +1477,7 @@
         if (dom(ib)%edgprev5.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e5m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1492,7 +1492,7 @@
         if (dom(ib)%edgprev6.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e6m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1507,7 +1507,7 @@
         if (dom(ib)%edgnext1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e1p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1522,7 +1522,7 @@
         if (dom(ib)%edgnext2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e2p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1537,7 +1537,7 @@
         if (dom(ib)%edgnext3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e3p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1552,7 +1552,7 @@
         if (dom(ib)%edgnext4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e4p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1567,7 +1567,7 @@
         if (dom(ib)%edgnext5.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e5p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1582,7 +1582,7 @@
         if (dom(ib)%edgnext6.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e6p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1602,7 +1602,8 @@
               if (dom(ib)%iprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%iprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%iprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m1(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  do k=kspr,kepr; do j=jspr,jepr; ijk=(k-1)*nj+j
                     fi(is-1-ly,j,k)=dom(ib) % recvb_m1(ijk)
@@ -1613,7 +1614,8 @@
               if (dom(ib)%jprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%jprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m2(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  do k=kspr,kepr; do i=ispr,iepr; ijk=(k-1)*ni+i
                     fi(i,js-1-ly,k)=dom(ib) % recvb_m2(ijk)
@@ -1624,7 +1626,8 @@
               if (dom(ib)%kprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%kprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%kprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m3(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  do i=ispr,iepr; do j=jspr,jepr; ijk=(i-1)*nj+j
                     fi(i,j,ks-1-ly)=dom(ib) % recvb_m3(ijk)
@@ -1638,7 +1641,8 @@
               if (dom(ib)%inext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%inext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%inext)) then
-                    call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p1(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  do k=kspr,kepr; do j=jspr,jepr; ijk=(k-1)*nj+j
                     fi(ie+1+ly,j,k)=dom(ib) % recvb_p1(ijk)
@@ -1649,7 +1653,8 @@
               if (dom(ib)%jnext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%jnext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jnext)) then
-                    call MPI_WAIT(dom(ib)%rq_p2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p2(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  do k=kspr,kepr; do i=ispr,iepr; ijk=(k-1)*ni+i
                     fi(i,je+1+ly,k)=dom(ib) % recvb_p2(ijk)
@@ -1660,7 +1665,8 @@
               if (dom(ib)%knext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%knext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%knext)) then
-                    call MPI_WAIT(dom(ib)%rq_p3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p3(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  do i=ispr,iepr; do j=jspr,jepr; ijk=(i-1)*nj+j
                     fi(i,j,ke+1+ly)=dom(ib) % recvb_p3(ijk)

--- a/source/exchangep.for
+++ b/source/exchangep.for
@@ -357,7 +357,7 @@
                  ta=2
                  call MPI_IRECV  (dom(ib)%recvb_m1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%iprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%iprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -426,7 +426,7 @@
                  ta=4
                  call MPI_IRECV  (dom(ib)%recvb_m2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m2(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m2(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%jprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -495,7 +495,7 @@
                  ta=6
                  call MPI_IRECV  (dom(ib)%recvb_m3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%kprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m3,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m3(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m3(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%kprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -566,7 +566,7 @@
                  ta=1
                  call MPI_IRECV  (dom(ib)%recvb_p1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%inext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%inext),tag,MPI_COMM_WORLD,ierr)
 
@@ -635,7 +635,7 @@
                  ta=3
                  call MPI_IRECV  (dom(ib)%recvb_p2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jnext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p2(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p2(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%jnext),tag,MPI_COMM_WORLD,ierr)
 
@@ -704,7 +704,7 @@
                  ta=5
                  call MPI_IRECV  (dom(ib)%recvb_p3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%knext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p3,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p3(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p3(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%knext),tag,MPI_COMM_WORLD,ierr)
 
@@ -743,7 +743,7 @@
                  tag=7*10**5+dom(ib)%corprev1
                  call MPI_IRECV  (dom(ib)%rc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),dom(ib)%tg(8),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1m(1),ierr)
                  call MPI_SEND (dom(ib)%sc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),tag,MPI_COMM_WORLD,ierr)
 
@@ -778,7 +778,7 @@
                  tag=9*10**5+dom(ib)%corprev2
                  call MPI_IRECV  (dom(ib)%rc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),dom(ib)%tg(10),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2m(1),ierr)
                  call MPI_SEND (dom(ib)%sc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -813,7 +813,7 @@
                  tag=11*10**5+dom(ib)%corprev3
                  call MPI_IRECV  (dom(ib)%rc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),dom(ib)%tg(12),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3m(1),ierr)
                  call MPI_SEND (dom(ib)%sc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -848,7 +848,7 @@
                  tag=13*10**5+dom(ib)%corprev4
                  call MPI_IRECV  (dom(ib)%rc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),dom(ib)%tg(14),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4m(1),ierr)
                  call MPI_SEND (dom(ib)%sc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -883,7 +883,7 @@
                  tag=8*10**5+dom(ib)%cornext1
                  call MPI_IRECV  (dom(ib)%rc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),dom(ib)%tg(7),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1p(1),ierr)
                  call MPI_SEND (dom(ib)%sc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -918,7 +918,7 @@
                  tag=10*10**5+dom(ib)%cornext2
              call MPI_IRECV  (dom(ib)%rc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),dom(ib)%tg(9),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2p(1),ierr)
                  call MPI_SEND (dom(ib)%sc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),tag,MPI_COMM_WORLD,ierr)
     
@@ -953,7 +953,7 @@
                  tag=12*10**5+dom(ib)%cornext3
                  call MPI_IRECV  (dom(ib)%rc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),dom(ib)%tg(11),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3p(1),ierr)
                  call MPI_SEND (dom(ib)%sc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),tag,MPI_COMM_WORLD,ierr)
 
@@ -988,7 +988,7 @@
                  tag=14*10**5+dom(ib)%cornext4
                  call MPI_IRECV  (dom(ib)%rc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),dom(ib)%tg(13),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4p(1),ierr)
                  call MPI_SEND (dom(ib)%sc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1025,7 +1025,7 @@
                  tag=15*10**5+dom(ib)%edgprev1
                  call MPI_IRECV  (dom(ib)%re1m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),dom(ib)%tg(16),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1m(1),ierr)
                  call MPI_SEND (dom(ib)%se1m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),tag,MPI_COMM_WORLD,ierr)
 
@@ -1062,7 +1062,7 @@
                  tag=17*10**5+dom(ib)%edgprev2
                  call MPI_IRECV  (dom(ib)%re2m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),dom(ib)%tg(18),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2m(1),ierr)
                  call MPI_SEND (dom(ib)%se2m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -1099,7 +1099,7 @@
                  tag=19*10**5+dom(ib)%edgprev3
                  call MPI_IRECV  (dom(ib)%re3m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),dom(ib)%tg(20),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3m(1),ierr)
                  call MPI_SEND (dom(ib)%se3m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -1136,7 +1136,7 @@
                  tag=21*10**5+dom(ib)%edgprev4
                  call MPI_IRECV  (dom(ib)%re4m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),dom(ib)%tg(22),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4m(1),ierr)
                  call MPI_SEND (dom(ib)%se4m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1173,7 +1173,7 @@
                  tag=23*10**5+dom(ib)%edgprev5
                  call MPI_IRECV  (dom(ib)%re5m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),dom(ib)%tg(24),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5m(1),ierr)
                  call MPI_SEND (dom(ib)%se5m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1210,7 +1210,7 @@
                  tag=25*10**5+dom(ib)%edgprev6
                  call MPI_IRECV  (dom(ib)%re6m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),dom(ib)%tg(26),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6m(1),ierr)
                  call MPI_SEND (dom(ib)%se6m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1247,7 +1247,7 @@
                  tag=16*10**5+dom(ib)%edgnext1
                  call MPI_IRECV  (dom(ib)%re1p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),dom(ib)%tg(15),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1p(1),ierr)
                  call MPI_SEND (dom(ib)%se1p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -1284,7 +1284,7 @@
                  tag=18*10**5+dom(ib)%edgnext2
                  call MPI_IRECV  (dom(ib)%re2p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),dom(ib)%tg(17),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2p(1),ierr)
                  call MPI_SEND (dom(ib)%se2p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),tag,MPI_COMM_WORLD,ierr)
 
@@ -1321,7 +1321,7 @@
                  tag=20*10**5+dom(ib)%edgnext3
                 call MPI_IRECV  (dom(ib)%re3p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),dom(ib)%tg(19),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3p(1),ierr)
                  call MPI_SEND (dom(ib)%se3p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),tag,MPI_COMM_WORLD,ierr)
  
@@ -1358,7 +1358,7 @@
                  tag=22*10**5+dom(ib)%edgnext4
                  call MPI_IRECV  (dom(ib)%re4p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),dom(ib)%tg(21),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4p(1),ierr)
                  call MPI_SEND (dom(ib)%se4p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1395,7 +1395,7 @@
                  tag=24*10**5+dom(ib)%edgnext5
                  call MPI_IRECV  (dom(ib)%re5p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),dom(ib)%tg(23),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5p(1),ierr)
                  call MPI_SEND (dom(ib)%se5p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1432,7 +1432,7 @@
                  tag=26*10**5+dom(ib)%edgnext6
                  call MPI_IRECV  (dom(ib)%re6p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),dom(ib)%tg(25),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6p(1),ierr)
                  call MPI_SEND (dom(ib)%se6p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1468,7 +1468,7 @@
         if (dom(ib)%corprev1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c1m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1483,7 +1483,7 @@
         if (dom(ib)%corprev2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c2m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1498,7 +1498,7 @@
         if (dom(ib)%corprev3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c3m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1513,7 +1513,7 @@
         if (dom(ib)%corprev4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c4m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1528,7 +1528,7 @@
         if (dom(ib)%cornext1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c1p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1543,7 +1543,7 @@
         if (dom(ib)%cornext2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c2p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1558,7 +1558,7 @@
         if (dom(ib)%cornext3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c3p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1573,7 +1573,7 @@
         if (dom(ib)%cornext4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c4p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1588,7 +1588,7 @@
         if (dom(ib)%edgprev1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e1m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1603,7 +1603,7 @@
         if (dom(ib)%edgprev2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e2m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1618,7 +1618,7 @@
         if (dom(ib)%edgprev3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e3m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1633,7 +1633,7 @@
         if (dom(ib)%edgprev4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e4m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1648,7 +1648,7 @@
         if (dom(ib)%edgprev5.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e5m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1663,7 +1663,7 @@
         if (dom(ib)%edgprev6.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e6m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1678,7 +1678,7 @@
         if (dom(ib)%edgnext1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e1p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1693,7 +1693,7 @@
         if (dom(ib)%edgnext2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e2p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1708,7 +1708,7 @@
         if (dom(ib)%edgnext3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e3p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1723,7 +1723,7 @@
         if (dom(ib)%edgnext4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e4p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1738,7 +1738,7 @@
         if (dom(ib)%edgnext5.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e5p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1753,7 +1753,7 @@
         if (dom(ib)%edgnext6.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e6p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1773,7 +1773,8 @@
               if (dom(ib)%iprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%iprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%iprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m1(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  if(rdiv(dom_id(ib)).lt.rdiv(dom(ib)%iprev)) then
                  do k=kspr,kepr; do j=jspr,jepr; ijk=(k-1)*nj+j
@@ -1794,7 +1795,8 @@
               if (dom(ib)%jprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%jprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m2(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  if(rdiv(dom_id(ib)).lt.rdiv(dom(ib)%jprev)) then
                  do k=kspr,kepr; do i=ispr,iepr; ijk=(k-1)*ni+i
@@ -1816,7 +1818,8 @@
               if (dom(ib)%kprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%kprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%kprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m3(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  if(rdiv(dom_id(ib)).lt.rdiv(dom(ib)%kprev)) then
                  do i=ispr,iepr; do j=jspr,jepr; ijk=(i-1)*nj+j
@@ -1840,7 +1843,8 @@
               if (dom(ib)%inext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%inext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%inext)) then
-                    call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p1(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  if(rdiv(dom_id(ib)).lt.rdiv(dom(ib)%inext)) then
                  do k=kspr,kepr; do j=jspr,jepr; ijk=(k-1)*nj+j
@@ -1862,7 +1866,8 @@
               if (dom(ib)%jnext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%jnext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jnext)) then
-                    call MPI_WAIT(dom(ib)%rq_p2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p2(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  if(rdiv(dom_id(ib)).lt.rdiv(dom(ib)%jnext)) then
                  do k=kspr,kepr; do i=ispr,iepr; ijk=(k-1)*ni+i
@@ -1884,7 +1889,8 @@
               if (dom(ib)%knext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%knext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%knext)) then
-                    call MPI_WAIT(dom(ib)%rq_p3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p3(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  if(rdiv(dom_id(ib)).lt.rdiv(dom(ib)%knext)) then
                  do i=ispr,iepr; do j=jspr,jepr; ijk=(i-1)*nj+j

--- a/source/exchangepp.for
+++ b/source/exchangepp.for
@@ -422,7 +422,8 @@
               tag=(2*sync_dir-1)*10**5+cpu_prev
               ta=2*sync_dir
               call MPI_IRECV  (dom(ib)%recvb_m1(1),trecv,MPI_FLT,
-     &dom_ad(cpu_prev),dom(ib)%tg(ta),MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
+     &dom_ad(cpu_prev),dom(ib)%tg(ta),MPI_COMM_WORLD,dom(ib)%rq_m1(1),
+     &ierr)
               call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
      &dom_ad(cpu_prev),tag,MPI_COMM_WORLD,ierr)
 
@@ -480,7 +481,7 @@
               tag=7*10**5+dom(ib)%corprev1
               call MPI_IRECV  (dom(ib)%rc1m,1,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),dom(ib)%tg(8),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1m(1),ierr)
               call MPI_SEND (dom(ib)%sc1m,1,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),tag,MPI_COMM_WORLD,ierr)
 
@@ -530,7 +531,7 @@
               tag=9*10**5+dom(ib)%corprev2
               call MPI_IRECV  (dom(ib)%rc2m,1,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),dom(ib)%tg(10),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2m(1),ierr)
               call MPI_SEND (dom(ib)%sc2m,1,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -580,7 +581,7 @@
               tag=11*10**5+dom(ib)%corprev3
               call MPI_IRECV  (dom(ib)%rc3m,1,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),dom(ib)%tg(12),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3m(1),ierr)
               call MPI_SEND (dom(ib)%sc3m,1,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -630,7 +631,7 @@
               tag=13*10**5+dom(ib)%corprev4
               call MPI_IRECV  (dom(ib)%rc4m,1,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),dom(ib)%tg(14),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4m(1),ierr)
               call MPI_SEND (dom(ib)%sc4m,1,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -712,7 +713,7 @@
               tag=15*10**5+dom(ib)%edgprev1
               call MPI_IRECV  (dom(ib)%re1m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),dom(ib)%tg(16),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1m(1),ierr)
               call MPI_SEND (dom(ib)%se1m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),tag,MPI_COMM_WORLD,ierr)
 
@@ -788,7 +789,7 @@
               tag=17*10**5+dom(ib)%edgprev2
               call MPI_IRECV  (dom(ib)%re2m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),dom(ib)%tg(18),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2m(1),ierr)
               call MPI_SEND (dom(ib)%se2m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -864,7 +865,7 @@
               tag=19*10**5+dom(ib)%edgprev3
               call MPI_IRECV  (dom(ib)%re3m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),dom(ib)%tg(20),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3m(1),ierr)
               call MPI_SEND (dom(ib)%se3m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -940,7 +941,7 @@
               tag=21*10**5+dom(ib)%edgprev4
               call MPI_IRECV  (dom(ib)%re4m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),dom(ib)%tg(22),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4m(1),ierr)
               call MPI_SEND (dom(ib)%se4m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1016,7 +1017,7 @@
               tag=23*10**5+dom(ib)%edgprev5
               call MPI_IRECV  (dom(ib)%re5m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),dom(ib)%tg(24),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5m(1),ierr)
               call MPI_SEND (dom(ib)%se5m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1092,7 +1093,7 @@
               tag=25*10**5+dom(ib)%edgprev6
               call MPI_IRECV  (dom(ib)%re6m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),dom(ib)%tg(26),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6m(1),ierr)
               call MPI_SEND (dom(ib)%se6m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1381,7 +1382,8 @@
               tag=(2*sync_dir)*10**5+cpu_next
               ta=2*sync_dir-1
               call MPI_IRECV  (dom(ib)%recvb_p1(1),trecv,MPI_FLT,
-     &dom_ad(cpu_next),dom(ib)%tg(ta),MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
+     &dom_ad(cpu_next),dom(ib)%tg(ta),MPI_COMM_WORLD,dom(ib)%rq_p1(1),
+     &ierr)
               call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
      &dom_ad(cpu_next),tag,MPI_COMM_WORLD,ierr)
 
@@ -1439,7 +1441,7 @@
               tag=8*10**5+dom(ib)%cornext1
               call MPI_IRECV  (dom(ib)%rc1p,1,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),dom(ib)%tg(7),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1p(1),ierr)
               call MPI_SEND (dom(ib)%sc1p,1,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -1489,7 +1491,7 @@
               tag=10*10**5+dom(ib)%cornext2
               call MPI_IRECV  (dom(ib)%rc2p,1,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),dom(ib)%tg(9),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2p(1),ierr)
               call MPI_SEND (dom(ib)%sc2p,1,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),tag,MPI_COMM_WORLD,ierr)
 
@@ -1539,7 +1541,7 @@
               tag=12*10**5+dom(ib)%cornext3
               call MPI_IRECV  (dom(ib)%rc3p,1,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),dom(ib)%tg(11),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3p(1),ierr)
               call MPI_SEND (dom(ib)%sc3p,1,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),tag,MPI_COMM_WORLD,ierr)
 
@@ -1589,7 +1591,7 @@
               tag=14*10**5+dom(ib)%cornext4
               call MPI_IRECV  (dom(ib)%rc4p,1,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),dom(ib)%tg(13),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4p(1),ierr)
               call MPI_SEND (dom(ib)%sc4p,1,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1670,7 +1672,7 @@
               tag=16*10**5+dom(ib)%edgnext1
               call MPI_IRECV  (dom(ib)%re1p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),dom(ib)%tg(15),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1p(1),ierr)
               call MPI_SEND (dom(ib)%se1p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -1746,7 +1748,7 @@
               tag=18*10**5+dom(ib)%edgnext2
               call MPI_IRECV  (dom(ib)%re2p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),dom(ib)%tg(17),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2p(1),ierr)
               call MPI_SEND (dom(ib)%se2p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),tag,MPI_COMM_WORLD,ierr)
 
@@ -1822,7 +1824,7 @@
               tag=20*10**5+dom(ib)%edgnext3
               call MPI_IRECV  (dom(ib)%re3p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),dom(ib)%tg(19),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3p(1),ierr)
               call MPI_SEND (dom(ib)%se3p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),tag,MPI_COMM_WORLD,ierr)
 
@@ -1898,7 +1900,7 @@
               tag=22*10**5+dom(ib)%edgnext4
               call MPI_IRECV  (dom(ib)%re4p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),dom(ib)%tg(21),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4p(1),ierr)
               call MPI_SEND (dom(ib)%se4p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1974,7 +1976,7 @@
               tag=24*10**5+dom(ib)%edgnext5
               call MPI_IRECV  (dom(ib)%re5p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),dom(ib)%tg(23),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5p(1),ierr)
               call MPI_SEND (dom(ib)%se5p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),tag,MPI_COMM_WORLD,ierr)
 
@@ -2050,7 +2052,7 @@
               tag=26*10**5+dom(ib)%edgnext6
               call MPI_IRECV  (dom(ib)%re6p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),dom(ib)%tg(25),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6p(1),ierr)
               call MPI_SEND (dom(ib)%se6p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),tag,MPI_COMM_WORLD,ierr)
 
@@ -2197,7 +2199,7 @@
 
                  else !if (dom_ad(dom_id(ib)) .ne. dom_ad(cpu_prev)) then
 
-                 call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_m1(1),MPI_STATUS_IGNORE,ierr)
                  rbuf_m => dom(ib) % recvb_m1
 !======================================================================
 !======================================================================
@@ -2402,7 +2404,8 @@
 
                  else !if (dom_ad(dom_id(ib)) .ne. dom_ad(cpu_next)) then
 
-                    call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p1(1),MPI_STATUS_IGNORE,
+     &ierr)
                     rbuf_p => dom(ib) % recvb_p1
 
 !======================================================================
@@ -2518,7 +2521,7 @@
               i=1; j=1; k=1; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=dom(ib) % rc1m(1)
            else
-              call MPI_WAIT(dom(ib)%rq_c1m,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_c1m(1),MPI_STATUS_IGNORE,ierr)
               rbufc1m => dom(ib) % rc1m
               i=1; j=1; k=1; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=rbufc1m(1)
@@ -2530,7 +2533,7 @@
               i=1; j=nj; k=1; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=dom(ib) % rc2m(1)
            else
-              call MPI_WAIT(dom(ib)%rq_c2m,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_c2m(1),MPI_STATUS_IGNORE,ierr)
               rbufc2m => dom(ib) % rc2m
               i=1; j=nj; k=1; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=rbufc2m(1)
@@ -2542,7 +2545,7 @@
               i=ni; j=nj; k=1; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=dom(ib) % rc3m(1)
            else
-              call MPI_WAIT(dom(ib)%rq_c3m,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_c3m(1),MPI_STATUS_IGNORE,ierr)
               rbufc3m => dom(ib) % rc3m
               i=ni; j=nj; k=1; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=rbufc3m(1)
@@ -2554,7 +2557,7 @@
               i=ni; j=1; k=1; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=dom(ib) % rc4m(1)
            else
-              call MPI_WAIT(dom(ib)%rq_c4m,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_c4m(1),MPI_STATUS_IGNORE,ierr)
               rbufc4m => dom(ib) % rc4m
               i=ni; j=1; k=1; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=rbufc4m(1)
@@ -2573,7 +2576,7 @@
                  fi(ll)=dom(ib) % re1m(nn)
               end do
            else
-              call MPI_WAIT(dom(ib)%rq_e1m,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_e1m(1),MPI_STATUS_IGNORE,ierr)
               rbufe1m => dom(ib) % re1m
               do nn=2,nj-1
                  i=1; j=nn; k=1; ll=(k-1)*nij+(i-1)*nj+j+nijk
@@ -2589,7 +2592,7 @@
                  fi(ll)=dom(ib) % re2m(nn)
               end do
            else
-              call MPI_WAIT(dom(ib)%rq_e2m,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_e2m(1),MPI_STATUS_IGNORE,ierr)
               rbufe2m => dom(ib) % re2m
               do nn=2,ni-1
                  i=nn; j=nj; k=1; ll=(k-1)*nij+(i-1)*nj+j+nijk
@@ -2605,7 +2608,7 @@
                  fi(ll)=dom(ib) % re3m(nn)
               end do
            else
-              call MPI_WAIT(dom(ib)%rq_e3m,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_e3m(1),MPI_STATUS_IGNORE,ierr)
               rbufe3m => dom(ib) % re3m
               do nn=2,nj-1
                  i=ni; j=nn; k=1; ll=(k-1)*nij+(i-1)*nj+j+nijk
@@ -2621,7 +2624,7 @@
                  fi(ll)=dom(ib) % re4m(nn)
               end do
            else
-              call MPI_WAIT(dom(ib)%rq_e4m,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_e4m(1),MPI_STATUS_IGNORE,ierr)
               rbufe4m => dom(ib) % re4m
               do nn=2,ni-1
                  i=nn; j=1; k=1; ll=(k-1)*nij+(i-1)*nj+j+nijk
@@ -2637,7 +2640,7 @@
                  fi(ll)=dom(ib) % re5m(nn)
               end do
            else
-              call MPI_WAIT(dom(ib)%rq_e5m,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_e5m(1),MPI_STATUS_IGNORE,ierr)
               rbufe5m => dom(ib) % re5m
               do nn=2,nk-1
                  i=1; j=1; k=nn; ll=(k-1)*nij+(i-1)*nj+j+nijk
@@ -2653,7 +2656,7 @@
                  fi(ll)=dom(ib) % re6m(nn)
               end do
            else
-              call MPI_WAIT(dom(ib)%rq_e6m,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_e6m(1),MPI_STATUS_IGNORE,ierr)
               rbufe6m => dom(ib) % re6m
               do nn=2,nk-1
                  i=1; j=nj; k=nn; ll=(k-1)*nij+(i-1)*nj+j+nijk
@@ -2671,7 +2674,7 @@
               i=ni; j=nj; k=nk; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=dom(ib) % rc1p(1)
            else
-              call MPI_WAIT(dom(ib)%rq_c1p,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_c1p(1),MPI_STATUS_IGNORE,ierr)
               rbufc1p => dom(ib) % rc1p
               i=ni; j=nj; k=nk; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=rbufc1p(1)
@@ -2683,7 +2686,7 @@
               i=ni; j=1; k=nk; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=dom(ib) % rc2p(1)
            else
-              call MPI_WAIT(dom(ib)%rq_c2p,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_c2p(1),MPI_STATUS_IGNORE,ierr)
               rbufc2p => dom(ib) % rc2p
               i=ni; j=1; k=nk; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=rbufc2p(1)
@@ -2695,7 +2698,7 @@
               i=1; j=1; k=nk; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=dom(ib) % rc3p(1)
            else
-              call MPI_WAIT(dom(ib)%rq_c3p,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_c3p(1),MPI_STATUS_IGNORE,ierr)
               rbufc3p => dom(ib) % rc3p
               i=1; j=1; k=nk; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=rbufc3p(1)
@@ -2707,7 +2710,7 @@
               i=1; j=nj; k=nk; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=dom(ib) % rc4p(1)
            else
-              call MPI_WAIT(dom(ib)%rq_c4p,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_c4p(1),MPI_STATUS_IGNORE,ierr)
               rbufc4p => dom(ib) % rc4p
               i=1; j=nj; k=nk; ll=(k-1)*nij+(i-1)*nj+j+nijk
               fi(ll)=rbufc4p(1)
@@ -2726,7 +2729,7 @@
                  fi(ll)=dom(ib) % re1p(nn)
               end do
            else
-              call MPI_WAIT(dom(ib)%rq_e1p,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_e1p(1),MPI_STATUS_IGNORE,ierr)
               rbufe1p => dom(ib) % re1p
               do nn=2,nj-1
                  i=ni; j=nn; k=nk; ll=(k-1)*nij+(i-1)*nj+j+nijk
@@ -2742,7 +2745,7 @@
                  fi(ll)=dom(ib) % re2p(nn)
               end do
            else
-              call MPI_WAIT(dom(ib)%rq_e2p,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_e2p(1),MPI_STATUS_IGNORE,ierr)
               rbufe2p => dom(ib) % re2p
               do nn=2,ni-1
                  i=nn; j=1; k=nk; ll=(k-1)*nij+(i-1)*nj+j+nijk
@@ -2758,7 +2761,7 @@
                  fi(ll)=dom(ib) % re3p(nn)
               end do
            else
-              call MPI_WAIT(dom(ib)%rq_e3p,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_e3p(1),MPI_STATUS_IGNORE,ierr)
               rbufe3p => dom(ib) % re3p
               do nn=2,nj-1
                  i=1; j=nn; k=nk; ll=(k-1)*nij+(i-1)*nj+j+nijk
@@ -2774,7 +2777,7 @@
                  fi(ll)=dom(ib) % re4p(nn)
               end do
            else
-              call MPI_WAIT(dom(ib)%rq_e4p,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_e4p(1),MPI_STATUS_IGNORE,ierr)
               rbufe4p => dom(ib) % re4p
               do nn=2,ni-1
                  i=nn; j=nj; k=nk; ll=(k-1)*nij+(i-1)*nj+j+nijk
@@ -2790,7 +2793,7 @@
                  fi(ll)=dom(ib) % re5p(nn)
               end do
            else
-              call MPI_WAIT(dom(ib)%rq_e5p,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_e5p(1),MPI_STATUS_IGNORE,ierr)
               rbufe5p => dom(ib) % re5p
               do nn=2,nk-1
                  i=ni; j=nj; k=nn; ll=(k-1)*nij+(i-1)*nj+j+nijk
@@ -2806,7 +2809,7 @@
                  fi(ll)=dom(ib) % re6p(nn)
               end do
            else
-              call MPI_WAIT(dom(ib)%rq_e6p,MPI_STATUS_IGNORE,ierr)
+              call MPI_WAIT(dom(ib)%rq_e6p(1),MPI_STATUS_IGNORE,ierr)
               rbufe6p => dom(ib) % re6p
               do nn=2,nk-1
                  i=ni; j=1; k=nn; ll=(k-1)*nij+(i-1)*nj+j+nijk
@@ -2906,7 +2909,7 @@
                     tag1=1*10**8+my_cor    *10**4+dom_id(ib)
                     tag2=2*10**8+dom_id(ib)*10**4+my_cor
                  call MPI_IRECV  (dom(ib)%recvb_m1(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
+     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag1,MPI_COMM_WORLD,ierr)
 
@@ -2956,7 +2959,7 @@
                     tag3=2*10**8+my_cor    *10**4+dom_id(ib)
                     tag4=1*10**8+dom_id(ib)*10**4+my_cor
                  call MPI_IRECV  (dom(ib)%recvb_p1(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
+     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag3,MPI_COMM_WORLD,ierr)
 
@@ -2998,7 +3001,7 @@
                  end do
 
               else !if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_m1(1),MPI_STATUS_IGNORE,ierr)
                  rbuf => dom(ib) % recvb_m1
 
                  do k=1,nk
@@ -3027,7 +3030,7 @@
                  end do
 
               else !if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_p1(1),MPI_STATUS_IGNORE,ierr)
                  rbuf => dom(ib) % recvb_p1
 
                  do k=1,nk
@@ -3105,7 +3108,7 @@
                     tag1=3*10**8+my_cor    *10**4+dom_id(ib)
                     tag2=4*10**8+dom_id(ib)*10**4+my_cor
                  call MPI_IRECV  (dom(ib)%recvb_m1(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
+     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag1,MPI_COMM_WORLD,ierr)
 
@@ -3156,7 +3159,7 @@
                     tag3=4*10**8+my_cor    *10**4+dom_id(ib)
                     tag4=3*10**8+dom_id(ib)*10**4+my_cor
                  call MPI_IRECV  (dom(ib)%recvb_p1(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
+     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag3,MPI_COMM_WORLD,ierr)
 
@@ -3198,7 +3201,7 @@
                  end do
 
               else !if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_m1(1),MPI_STATUS_IGNORE,ierr)
                  rbuf => dom(ib) % recvb_m1
 
                  do k=1,nk
@@ -3227,7 +3230,7 @@
                  end do
 
               else !if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_p1(1),MPI_STATUS_IGNORE,ierr)
                  rbuf => dom(ib) % recvb_p1
 
                  do k=1,nk
@@ -3305,7 +3308,7 @@
                     tag1=5*10**8+my_cor    *10**4+dom_id(ib)
                     tag2=6*10**8+dom_id(ib)*10**4+my_cor
                  call MPI_IRECV  (dom(ib)%recvb_m1(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
+     &dom_ad(my_cor),tag2,MPI_COMM_WORLD,dom(ib)%rq_m1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag1,MPI_COMM_WORLD,ierr)
 
@@ -3357,7 +3360,7 @@
                     tag3=6*10**8+my_cor    *10**4+dom_id(ib)
                     tag4=5*10**8+dom_id(ib)*10**4+my_cor
                  call MPI_IRECV  (dom(ib)%recvb_p1(1),tsend,MPI_FLT,
-     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
+     &dom_ad(my_cor),tag4,MPI_COMM_WORLD,dom(ib)%rq_p1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
      &dom_ad(my_cor),tag3,MPI_COMM_WORLD,ierr)
 
@@ -3399,7 +3402,7 @@
                  end do
 
               else !if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_m1(1),MPI_STATUS_IGNORE,ierr)
                  rbuf => dom(ib) % recvb_m1
 
                  do j=1,nj
@@ -3427,7 +3430,7 @@
                  end do
 
               else !if (dom_ad(dom_id(ib)) .ne. dom_ad(my_cor)) then
-                 call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_p1(1),MPI_STATUS_IGNORE,ierr)
                  rbuf => dom(ib) % recvb_p1
 
                  do j=1,nj

--- a/source/exchangesca.for
+++ b/source/exchangesca.for
@@ -349,7 +349,7 @@
                  ta=2
                call MPI_IRECV  (dom(ib)%recvb_m1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%iprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%iprev),tag,MPI_COMM_WORLD,ierr)
   
@@ -385,7 +385,7 @@
                  ta=4
                  call MPI_IRECV  (dom(ib)%recvb_m2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m2(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m2(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%jprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -421,7 +421,7 @@
                  ta=6
                  call MPI_IRECV  (dom(ib)%recvb_m3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%kprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m3,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m3(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m3(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%kprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -459,7 +459,7 @@
                  ta=1
                  call MPI_IRECV  (dom(ib)%recvb_p1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%inext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%inext),tag,MPI_COMM_WORLD,ierr)
 
@@ -495,7 +495,7 @@
                  ta=3
                  call MPI_IRECV  (dom(ib)%recvb_p2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jnext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p2(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p2(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%jnext),tag,MPI_COMM_WORLD,ierr)
 
@@ -531,7 +531,7 @@
                  ta=5
                  call MPI_IRECV  (dom(ib)%recvb_p3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%knext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p3,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p3(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p3(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%knext),tag,MPI_COMM_WORLD,ierr)
 
@@ -571,7 +571,7 @@
                  tag=7*10**5+dom(ib)%corprev1
                  call MPI_IRECV  (dom(ib)%rc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),dom(ib)%tg(8),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1m(1),ierr)
                  call MPI_SEND (dom(ib)%sc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),tag,MPI_COMM_WORLD,ierr)
 
@@ -606,7 +606,7 @@
                  tag=9*10**5+dom(ib)%corprev2
                  call MPI_IRECV  (dom(ib)%rc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),dom(ib)%tg(10),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2m(1),ierr)
                  call MPI_SEND (dom(ib)%sc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -641,7 +641,7 @@
                  tag=11*10**5+dom(ib)%corprev3
                  call MPI_IRECV  (dom(ib)%rc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),dom(ib)%tg(12),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3m(1),ierr)
                  call MPI_SEND (dom(ib)%sc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -676,7 +676,7 @@
                  tag=13*10**5+dom(ib)%corprev4
                  call MPI_IRECV  (dom(ib)%rc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),dom(ib)%tg(14),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4m(1),ierr)
                  call MPI_SEND (dom(ib)%sc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -711,7 +711,7 @@
                  tag=8*10**5+dom(ib)%cornext1
                  call MPI_IRECV  (dom(ib)%rc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),dom(ib)%tg(7),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1p(1),ierr)
                  call MPI_SEND (dom(ib)%sc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -746,7 +746,7 @@
                  tag=10*10**5+dom(ib)%cornext2
                  call MPI_IRECV  (dom(ib)%rc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),dom(ib)%tg(9),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2p(1),ierr)
                  call MPI_SEND (dom(ib)%sc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),tag,MPI_COMM_WORLD,ierr)
 
@@ -781,7 +781,7 @@
                  tag=12*10**5+dom(ib)%cornext3
                  call MPI_IRECV  (dom(ib)%rc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),dom(ib)%tg(11),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3p(1),ierr)
                  call MPI_SEND (dom(ib)%sc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),tag,MPI_COMM_WORLD,ierr)
 
@@ -816,7 +816,7 @@
                  tag=14*10**5+dom(ib)%cornext4
                  call MPI_IRECV  (dom(ib)%rc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),dom(ib)%tg(13),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4p(1),ierr)
                  call MPI_SEND (dom(ib)%sc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -853,7 +853,7 @@
                  tag=15*10**5+dom(ib)%edgprev1
                  call MPI_IRECV  (dom(ib)%re1m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),dom(ib)%tg(16),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1m(1),ierr)
                  call MPI_SEND (dom(ib)%se1m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),tag,MPI_COMM_WORLD,ierr)
 
@@ -890,7 +890,7 @@
                  tag=17*10**5+dom(ib)%edgprev2
                  call MPI_IRECV  (dom(ib)%re2m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),dom(ib)%tg(18),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2m(1),ierr)
                  call MPI_SEND (dom(ib)%se2m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -927,7 +927,7 @@
                  tag=19*10**5+dom(ib)%edgprev3
                  call MPI_IRECV  (dom(ib)%re3m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),dom(ib)%tg(20),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3m(1),ierr)
                  call MPI_SEND (dom(ib)%se3m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -964,7 +964,7 @@
                  tag=21*10**5+dom(ib)%edgprev4
                  call MPI_IRECV  (dom(ib)%re4m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),dom(ib)%tg(22),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4m(1),ierr)
                  call MPI_SEND (dom(ib)%se4m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1001,7 +1001,7 @@
                  tag=23*10**5+dom(ib)%edgprev5
                  call MPI_IRECV  (dom(ib)%re5m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),dom(ib)%tg(24),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5m(1),ierr)
                  call MPI_SEND (dom(ib)%se5m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1038,7 +1038,7 @@
                  tag=25*10**5+dom(ib)%edgprev6
                  call MPI_IRECV  (dom(ib)%re6m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),dom(ib)%tg(26),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6m(1),ierr)
                  call MPI_SEND (dom(ib)%se6m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1075,7 +1075,7 @@
                  tag=16*10**5+dom(ib)%edgnext1
                  call MPI_IRECV  (dom(ib)%re1p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),dom(ib)%tg(15),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1p(1),ierr)
                  call MPI_SEND (dom(ib)%se1p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -1112,7 +1112,7 @@
                  tag=18*10**5+dom(ib)%edgnext2
                  call MPI_IRECV  (dom(ib)%re2p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),dom(ib)%tg(17),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2p(1),ierr)
                  call MPI_SEND (dom(ib)%se2p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),tag,MPI_COMM_WORLD,ierr)
 
@@ -1149,7 +1149,7 @@
                  tag=20*10**5+dom(ib)%edgnext3
                  call MPI_IRECV  (dom(ib)%re3p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),dom(ib)%tg(19),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3p(1),ierr)
                  call MPI_SEND (dom(ib)%se3p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),tag,MPI_COMM_WORLD,ierr)
 
@@ -1186,7 +1186,7 @@
                  tag=22*10**5+dom(ib)%edgnext4
                  call MPI_IRECV  (dom(ib)%re4p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),dom(ib)%tg(21),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4p(1),ierr)
                  call MPI_SEND (dom(ib)%se4p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1223,7 +1223,7 @@
                  tag=24*10**5+dom(ib)%edgnext5
                  call MPI_IRECV  (dom(ib)%re5p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),dom(ib)%tg(23),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5p(1),ierr)
                  call MPI_SEND (dom(ib)%se5p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1260,7 +1260,7 @@
                  tag=26*10**5+dom(ib)%edgnext6
                  call MPI_IRECV  (dom(ib)%re6p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),dom(ib)%tg(25),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6p(1),ierr)
                  call MPI_SEND (dom(ib)%se6p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1304,7 +1304,7 @@
         if (dom(ib)%corprev1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c1m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1319,7 +1319,7 @@
         if (dom(ib)%corprev2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c2m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1334,7 +1334,7 @@
         if (dom(ib)%corprev3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c3m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1349,7 +1349,7 @@
         if (dom(ib)%corprev4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c4m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1364,7 +1364,7 @@
         if (dom(ib)%cornext1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c1p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1379,7 +1379,7 @@
         if (dom(ib)%cornext2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c2p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1394,7 +1394,7 @@
         if (dom(ib)%cornext3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c3p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1409,7 +1409,7 @@
         if (dom(ib)%cornext4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c4p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1424,7 +1424,7 @@
         if (dom(ib)%edgprev1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e1m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1439,7 +1439,7 @@
         if (dom(ib)%edgprev2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e2m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1454,7 +1454,7 @@
         if (dom(ib)%edgprev3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e3m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1469,7 +1469,7 @@
         if (dom(ib)%edgprev4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e4m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1484,7 +1484,7 @@
         if (dom(ib)%edgprev5.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e5m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1499,7 +1499,7 @@
         if (dom(ib)%edgprev6.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e6m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1514,7 +1514,7 @@
         if (dom(ib)%edgnext1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e1p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1529,7 +1529,7 @@
         if (dom(ib)%edgnext2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e2p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1544,7 +1544,7 @@
         if (dom(ib)%edgnext3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e3p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1559,7 +1559,7 @@
         if (dom(ib)%edgnext4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e4p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1574,7 +1574,7 @@
         if (dom(ib)%edgnext5.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e5p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1589,7 +1589,7 @@
         if (dom(ib)%edgnext6.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e6p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1609,7 +1609,8 @@
               if (dom(ib)%iprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%iprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%iprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m1(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  do k=kspr,kepr; do j=jspr,jepr; ijk=(k-1)*nj+j
                     fi(is-1-ly,j,k)=dom(ib) % recvb_m1(ijk)
@@ -1620,7 +1621,8 @@
               if (dom(ib)%jprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%jprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m2(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  do k=kspr,kepr; do i=ispr,iepr; ijk=(k-1)*ni+i
                     fi(i,js-1-ly,k)=dom(ib) % recvb_m2(ijk)
@@ -1631,7 +1633,8 @@
               if (dom(ib)%kprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%kprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%kprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m3(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  do i=ispr,iepr; do j=jspr,jepr; ijk=(i-1)*nj+j
                     fi(i,j,ks-1-ly)=dom(ib) % recvb_m3(ijk)
@@ -1645,7 +1648,8 @@
               if (dom(ib)%inext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%inext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%inext)) then
-                    call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p1(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  do k=kspr,kepr; do j=jspr,jepr; ijk=(k-1)*nj+j
                     fi(ie+1+ly,j,k)=dom(ib) % recvb_p1(ijk)
@@ -1656,7 +1660,8 @@
               if (dom(ib)%jnext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%jnext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jnext)) then
-                    call MPI_WAIT(dom(ib)%rq_p2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p2(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  do k=kspr,kepr; do i=ispr,iepr; ijk=(k-1)*ni+i
                     fi(i,je+1+ly,k)=dom(ib) % recvb_p2(ijk)
@@ -1667,7 +1672,8 @@
               if (dom(ib)%knext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%knext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%knext)) then
-                    call MPI_WAIT(dom(ib)%rq_p3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p3(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  do i=ispr,iepr; do j=jspr,jepr; ijk=(i-1)*nj+j
                     fi(i,j,ke+1+ly)=dom(ib) % recvb_p3(ijk)

--- a/source/exchangeu.for
+++ b/source/exchangeu.for
@@ -389,7 +389,7 @@
                  ta=2
                  call MPI_IRECV  (dom(ib)%recvb_m1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%iprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%iprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -425,7 +425,7 @@
                  ta=4
                  call MPI_IRECV  (dom(ib)%recvb_m2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m2(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m2(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%jprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -461,7 +461,7 @@
                  ta=6
                  call MPI_IRECV  (dom(ib)%recvb_m3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%kprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m3,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m3(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m3(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%kprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -514,7 +514,7 @@
                  ta=1
                  call MPI_IRECV  (dom(ib)%recvb_p1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%inext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%inext),tag,MPI_COMM_WORLD,ierr)
 
@@ -550,7 +550,7 @@
                  ta=3
                  call MPI_IRECV  (dom(ib)%recvb_p2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jnext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p2(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p2(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%jnext),tag,MPI_COMM_WORLD,ierr)
 
@@ -586,7 +586,7 @@
                  ta=5
                  call MPI_IRECV  (dom(ib)%recvb_p3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%knext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p3,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p3(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p3(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%knext),tag,MPI_COMM_WORLD,ierr)
 
@@ -626,7 +626,7 @@
                  tag=7*10**5+dom(ib)%corprev1
                  call MPI_IRECV  (dom(ib)%rc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),dom(ib)%tg(8),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1m(1),ierr)
                  call MPI_SEND (dom(ib)%sc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),tag,MPI_COMM_WORLD,ierr)
 
@@ -661,7 +661,7 @@
                  tag=9*10**5+dom(ib)%corprev2
                  call MPI_IRECV  (dom(ib)%rc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),dom(ib)%tg(10),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2m(1),ierr)
                  call MPI_SEND (dom(ib)%sc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -696,7 +696,7 @@
                  tag=11*10**5+dom(ib)%corprev3
                  call MPI_IRECV  (dom(ib)%rc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),dom(ib)%tg(12),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3m(1),ierr)
                  call MPI_SEND (dom(ib)%sc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -731,7 +731,7 @@
                  tag=13*10**5+dom(ib)%corprev4
                  call MPI_IRECV  (dom(ib)%rc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),dom(ib)%tg(14),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4m(1),ierr)
                  call MPI_SEND (dom(ib)%sc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -766,7 +766,7 @@
                  tag=8*10**5+dom(ib)%cornext1
                  call MPI_IRECV  (dom(ib)%rc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),dom(ib)%tg(7),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1p(1),ierr)
                  call MPI_SEND (dom(ib)%sc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -801,7 +801,7 @@
                  tag=10*10**5+dom(ib)%cornext2
                  call MPI_IRECV  (dom(ib)%rc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),dom(ib)%tg(9),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2p(1),ierr)
                  call MPI_SEND (dom(ib)%sc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),tag,MPI_COMM_WORLD,ierr)
 
@@ -836,7 +836,7 @@
                  tag=12*10**5+dom(ib)%cornext3
                  call MPI_IRECV  (dom(ib)%rc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),dom(ib)%tg(11),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3p(1),ierr)
                  call MPI_SEND (dom(ib)%sc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),tag,MPI_COMM_WORLD,ierr)
 
@@ -871,7 +871,7 @@
                  tag=14*10**5+dom(ib)%cornext4
                  call MPI_IRECV  (dom(ib)%rc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),dom(ib)%tg(13),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4p(1),ierr)
                  call MPI_SEND (dom(ib)%sc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -908,7 +908,7 @@
                  tag=15*10**5+dom(ib)%edgprev1
                  call MPI_IRECV  (dom(ib)%re1m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),dom(ib)%tg(16),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1m(1),ierr)
                  call MPI_SEND (dom(ib)%se1m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),tag,MPI_COMM_WORLD,ierr)
 
@@ -945,7 +945,7 @@
                  tag=17*10**5+dom(ib)%edgprev2
                  call MPI_IRECV  (dom(ib)%re2m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),dom(ib)%tg(18),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2m(1),ierr)
                  call MPI_SEND (dom(ib)%se2m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -982,7 +982,7 @@
                  tag=19*10**5+dom(ib)%edgprev3
                  call MPI_IRECV  (dom(ib)%re3m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),dom(ib)%tg(20),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3m(1),ierr)
                  call MPI_SEND (dom(ib)%se3m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -1019,7 +1019,7 @@
                  tag=21*10**5+dom(ib)%edgprev4
                  call MPI_IRECV  (dom(ib)%re4m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),dom(ib)%tg(22),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4m(1),ierr)
                  call MPI_SEND (dom(ib)%se4m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1056,7 +1056,7 @@
                  tag=23*10**5+dom(ib)%edgprev5
                  call MPI_IRECV  (dom(ib)%re5m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),dom(ib)%tg(24),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5m(1),ierr)
                  call MPI_SEND (dom(ib)%se5m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1093,7 +1093,7 @@
                  tag=25*10**5+dom(ib)%edgprev6
                  call MPI_IRECV  (dom(ib)%re6m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),dom(ib)%tg(26),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6m(1),ierr)
                  call MPI_SEND (dom(ib)%se6m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1130,7 +1130,7 @@
                  tag=16*10**5+dom(ib)%edgnext1
                  call MPI_IRECV  (dom(ib)%re1p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),dom(ib)%tg(15),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1p(1),ierr)
                  call MPI_SEND (dom(ib)%se1p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -1167,7 +1167,7 @@
                  tag=18*10**5+dom(ib)%edgnext2
                  call MPI_IRECV  (dom(ib)%re2p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),dom(ib)%tg(17),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2p(1),ierr)
                  call MPI_SEND (dom(ib)%se2p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),tag,MPI_COMM_WORLD,ierr)
 
@@ -1204,7 +1204,7 @@
                  tag=20*10**5+dom(ib)%edgnext3
                 call MPI_IRECV  (dom(ib)%re3p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),dom(ib)%tg(19),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3p(1),ierr)
                  call MPI_SEND (dom(ib)%se3p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),tag,MPI_COMM_WORLD,ierr)
  
@@ -1241,7 +1241,7 @@
                  tag=22*10**5+dom(ib)%edgnext4
                  call MPI_IRECV  (dom(ib)%re4p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),dom(ib)%tg(21),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4p(1),ierr)
                  call MPI_SEND (dom(ib)%se4p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1278,7 +1278,7 @@
                  tag=24*10**5+dom(ib)%edgnext5
                  call MPI_IRECV  (dom(ib)%re5p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),dom(ib)%tg(23),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5p(1),ierr)
                  call MPI_SEND (dom(ib)%se5p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1315,7 +1315,7 @@
                  tag=26*10**5+dom(ib)%edgnext6
                  call MPI_IRECV  (dom(ib)%re6p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),dom(ib)%tg(25),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6p(1),ierr)
                  call MPI_SEND (dom(ib)%se6p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1352,7 +1352,7 @@
         if (dom(ib)%corprev1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c1m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1367,7 +1367,7 @@
         if (dom(ib)%corprev2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c2m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1382,7 +1382,7 @@
         if (dom(ib)%corprev3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c3m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
 !              if(LMR.eq.2 .and.
@@ -1399,7 +1399,7 @@
         if (dom(ib)%corprev4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c4m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
 !              if(LMR.eq.2 .and.
@@ -1416,7 +1416,7 @@
         if (dom(ib)%cornext1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c1p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
 !              if(LMR.eq.2 .and.
@@ -1433,7 +1433,7 @@
         if (dom(ib)%cornext2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c2p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
 !              if(LMR.eq.2 .and.
@@ -1450,7 +1450,7 @@
         if (dom(ib)%cornext3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c3p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1465,7 +1465,7 @@
         if (dom(ib)%cornext4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c4p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1480,7 +1480,7 @@
         if (dom(ib)%edgprev1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e1m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1495,7 +1495,7 @@
         if (dom(ib)%edgprev2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e2m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1510,7 +1510,7 @@
         if (dom(ib)%edgprev3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e3m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
 !              if(LMR.eq.2 .and.
@@ -1527,7 +1527,7 @@
         if (dom(ib)%edgprev4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e4m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1542,7 +1542,7 @@
         if (dom(ib)%edgprev5.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e5m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1557,7 +1557,7 @@
         if (dom(ib)%edgprev6.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e6m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1572,7 +1572,7 @@
         if (dom(ib)%edgnext1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e1p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
 !              if(LMR.eq.2 .and.
@@ -1589,7 +1589,7 @@
         if (dom(ib)%edgnext2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e2p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1604,7 +1604,7 @@
         if (dom(ib)%edgnext3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e3p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1619,7 +1619,7 @@
         if (dom(ib)%edgnext4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e4p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1634,7 +1634,7 @@
         if (dom(ib)%edgnext5.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e5p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
 !              if(LMR.eq.2 .and.
@@ -1651,7 +1651,7 @@
         if (dom(ib)%edgnext6.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e6p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
 !              if(LMR.eq.2 .and.
@@ -1673,7 +1673,8 @@
               if (dom(ib)%iprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%iprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%iprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m1(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1694,7 +1695,8 @@
               if (dom(ib)%jprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%jprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m2(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1713,7 +1715,8 @@
               if (dom(ib)%kprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%kprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%kprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m3(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1736,7 +1739,8 @@
               if (dom(ib)%inext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%inext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%inext)) then
-                    call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p1(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1757,7 +1761,8 @@
               if (dom(ib)%jnext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%jnext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jnext)) then
-                    call MPI_WAIT(dom(ib)%rq_p2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p2(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1776,7 +1781,8 @@
               if (dom(ib)%knext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%knext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%knext)) then
-                    call MPI_WAIT(dom(ib)%rq_p3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p3(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl

--- a/source/exchangev.for
+++ b/source/exchangev.for
@@ -373,7 +373,7 @@
                  ta=2 
                 call MPI_IRECV  (dom(ib)%recvb_m1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%iprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%iprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -424,7 +424,7 @@
                  ta=4
                  call MPI_IRECV  (dom(ib)%recvb_m2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m2(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m2(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%jprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -460,7 +460,7 @@
                  ta=6
                  call MPI_IRECV  (dom(ib)%recvb_m3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%kprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m3,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m3(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m3(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%kprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -498,7 +498,7 @@
                  ta=1
                  call MPI_IRECV  (dom(ib)%recvb_p1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%inext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%inext),tag,MPI_COMM_WORLD,ierr)
 
@@ -549,7 +549,7 @@
                  ta=3
                  call MPI_IRECV  (dom(ib)%recvb_p2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jnext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p2(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p2(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%jnext),tag,MPI_COMM_WORLD,ierr)
 
@@ -585,7 +585,7 @@
                  ta=5
                  call MPI_IRECV  (dom(ib)%recvb_p3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%knext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p3,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p3(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p3(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%knext),tag,MPI_COMM_WORLD,ierr)
 
@@ -625,7 +625,7 @@
                  tag=7*10**5+dom(ib)%corprev1
                  call MPI_IRECV  (dom(ib)%rc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),dom(ib)%tg(8),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1m(1),ierr)
                  call MPI_SEND (dom(ib)%sc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),tag,MPI_COMM_WORLD,ierr)
 
@@ -660,7 +660,7 @@
                  tag=9*10**5+dom(ib)%corprev2
                  call MPI_IRECV  (dom(ib)%rc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),dom(ib)%tg(10),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2m(1),ierr)
                  call MPI_SEND (dom(ib)%sc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -695,7 +695,7 @@
                  tag=11*10**5+dom(ib)%corprev3
                  call MPI_IRECV  (dom(ib)%rc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),dom(ib)%tg(12),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3m(1),ierr)
                  call MPI_SEND (dom(ib)%sc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -730,7 +730,7 @@
                  tag=13*10**5+dom(ib)%corprev4
                  call MPI_IRECV  (dom(ib)%rc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),dom(ib)%tg(14),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4m(1),ierr)
                  call MPI_SEND (dom(ib)%sc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -765,7 +765,7 @@
                  tag=8*10**5+dom(ib)%cornext1
                  call MPI_IRECV  (dom(ib)%rc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),dom(ib)%tg(7),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1p(1),ierr)
                  call MPI_SEND (dom(ib)%sc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -800,7 +800,7 @@
                  tag=10*10**5+dom(ib)%cornext2
                  call MPI_IRECV  (dom(ib)%rc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),dom(ib)%tg(9),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2p(1),ierr)
                  call MPI_SEND (dom(ib)%sc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),tag,MPI_COMM_WORLD,ierr)
 
@@ -835,7 +835,7 @@
                  tag=12*10**5+dom(ib)%cornext3
                  call MPI_IRECV  (dom(ib)%rc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),dom(ib)%tg(11),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3p(1),ierr)
                  call MPI_SEND (dom(ib)%sc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),tag,MPI_COMM_WORLD,ierr)
 
@@ -870,7 +870,7 @@
                  tag=14*10**5+dom(ib)%cornext4
                  call MPI_IRECV  (dom(ib)%rc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),dom(ib)%tg(13),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4p(1),ierr)
                  call MPI_SEND (dom(ib)%sc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -907,7 +907,7 @@
                  tag=15*10**5+dom(ib)%edgprev1
                  call MPI_IRECV  (dom(ib)%re1m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),dom(ib)%tg(16),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1m(1),ierr)
                  call MPI_SEND (dom(ib)%se1m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),tag,MPI_COMM_WORLD,ierr)
 
@@ -944,7 +944,7 @@
                  tag=17*10**5+dom(ib)%edgprev2
                  call MPI_IRECV  (dom(ib)%re2m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),dom(ib)%tg(18),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2m(1),ierr)
                  call MPI_SEND (dom(ib)%se2m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -981,7 +981,7 @@
                  tag=19*10**5+dom(ib)%edgprev3
                  call MPI_IRECV  (dom(ib)%re3m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),dom(ib)%tg(20),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3m(1),ierr)
                  call MPI_SEND (dom(ib)%se3m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -1018,7 +1018,7 @@
                  tag=21*10**5+dom(ib)%edgprev4
                  call MPI_IRECV  (dom(ib)%re4m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),dom(ib)%tg(22),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4m(1),ierr)
                  call MPI_SEND (dom(ib)%se4m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1055,7 +1055,7 @@
                  tag=23*10**5+dom(ib)%edgprev5
                  call MPI_IRECV  (dom(ib)%re5m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),dom(ib)%tg(24),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5m(1),ierr)
                  call MPI_SEND (dom(ib)%se5m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1092,7 +1092,7 @@
                  tag=25*10**5+dom(ib)%edgprev6
                  call MPI_IRECV  (dom(ib)%re6m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),dom(ib)%tg(26),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6m(1),ierr)
                  call MPI_SEND (dom(ib)%se6m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1129,7 +1129,7 @@
                  tag=16*10**5+dom(ib)%edgnext1
                  call MPI_IRECV  (dom(ib)%re1p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),dom(ib)%tg(15),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1p(1),ierr)
                  call MPI_SEND (dom(ib)%se1p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -1166,7 +1166,7 @@
                  tag=18*10**5+dom(ib)%edgnext2
                  call MPI_IRECV  (dom(ib)%re2p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),dom(ib)%tg(17),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2p(1),ierr)
                  call MPI_SEND (dom(ib)%se2p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),tag,MPI_COMM_WORLD,ierr)
 
@@ -1203,7 +1203,7 @@
                  tag=20*10**5+dom(ib)%edgnext3
                  call MPI_IRECV  (dom(ib)%re3p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),dom(ib)%tg(19),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3p(1),ierr)
                  call MPI_SEND (dom(ib)%se3p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),tag,MPI_COMM_WORLD,ierr)
 
@@ -1240,7 +1240,7 @@
                  tag=22*10**5+dom(ib)%edgnext4
                  call MPI_IRECV  (dom(ib)%re4p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),dom(ib)%tg(21),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4p(1),ierr)
                  call MPI_SEND (dom(ib)%se4p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1277,7 +1277,7 @@
                  tag=24*10**5+dom(ib)%edgnext5
                  call MPI_IRECV  (dom(ib)%re5p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),dom(ib)%tg(23),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5p(1),ierr)
                  call MPI_SEND (dom(ib)%se5p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1314,7 +1314,7 @@
                  tag=26*10**5+dom(ib)%edgnext6
                  call MPI_IRECV  (dom(ib)%re6p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),dom(ib)%tg(25),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6p(1),ierr)
                  call MPI_SEND (dom(ib)%se6p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1351,7 +1351,7 @@
         if (dom(ib)%corprev1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c1m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1366,7 +1366,7 @@
         if (dom(ib)%corprev2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c2m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
 !              if(LMR.eq.2 .and.
@@ -1383,7 +1383,7 @@
         if (dom(ib)%corprev3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c3m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
 !              if(LMR.eq.2 .and.
@@ -1400,7 +1400,7 @@
         if (dom(ib)%corprev4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c4m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1415,7 +1415,7 @@
         if (dom(ib)%cornext1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c1p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
 !              if(LMR.eq.2 .and.
@@ -1432,7 +1432,7 @@
         if (dom(ib)%cornext2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c2p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1447,7 +1447,7 @@
         if (dom(ib)%cornext3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c3p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1462,7 +1462,7 @@
         if (dom(ib)%cornext4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c4p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
 !              if(LMR.eq.2 .and.
@@ -1479,7 +1479,7 @@
         if (dom(ib)%edgprev1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e1m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1494,7 +1494,7 @@
         if (dom(ib)%edgprev2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e2m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
 !              if(LMR.eq.2 .and.
@@ -1511,7 +1511,7 @@
         if (dom(ib)%edgprev3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e3m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1526,7 +1526,7 @@
         if (dom(ib)%edgprev4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e4m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1541,7 +1541,7 @@
         if (dom(ib)%edgprev5.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e5m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1556,7 +1556,7 @@
         if (dom(ib)%edgprev6.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e6m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
 !              if(LMR.eq.2 .and.
@@ -1573,7 +1573,7 @@
         if (dom(ib)%edgnext1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e1p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1588,7 +1588,7 @@
         if (dom(ib)%edgnext2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e2p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1603,7 +1603,7 @@
         if (dom(ib)%edgnext3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e3p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1618,7 +1618,7 @@
         if (dom(ib)%edgnext4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e4p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
 !              if(LMR.eq.2 .and.
@@ -1635,7 +1635,7 @@
         if (dom(ib)%edgnext5.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e5p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
 !              if(LMR.eq.2 .and.
@@ -1652,7 +1652,7 @@
         if (dom(ib)%edgnext6.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e6p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1672,7 +1672,8 @@
               if (dom(ib)%iprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%iprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%iprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m1(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1691,7 +1692,8 @@
               if (dom(ib)%jprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%jprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m2(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1714,7 +1716,8 @@
               if (dom(ib)%kprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%kprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%kprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m3(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1736,7 +1739,8 @@
               if (dom(ib)%inext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%inext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%inext)) then
-                    call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p1(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1755,7 +1759,8 @@
               if (dom(ib)%jnext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%jnext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jnext)) then
-                    call MPI_WAIT(dom(ib)%rq_p2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p2(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1776,7 +1781,8 @@
               if (dom(ib)%knext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%knext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%knext)) then
-                    call MPI_WAIT(dom(ib)%rq_p3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p3(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl

--- a/source/exchangew.for
+++ b/source/exchangew.for
@@ -372,7 +372,7 @@
                  ta=2
                  call MPI_IRECV  (dom(ib)%recvb_m1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%iprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m1,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m1(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%iprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -408,7 +408,7 @@
                  ta=4
                  call MPI_IRECV  (dom(ib)%recvb_m2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m2(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m2(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%jprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -459,7 +459,7 @@
                  ta=6
                  call MPI_IRECV  (dom(ib)%recvb_m3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%kprev),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_m3,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_m3(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_m3(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%kprev),tag,MPI_COMM_WORLD,ierr)
 
@@ -497,7 +497,7 @@
                  ta=1
                  call MPI_IRECV  (dom(ib)%recvb_p1(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%inext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p1,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p1(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p1(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%inext),tag,MPI_COMM_WORLD,ierr)
 
@@ -533,7 +533,7 @@
                  ta=3
                  call MPI_IRECV  (dom(ib)%recvb_p2(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%jnext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p2,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p2(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p2(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%jnext),tag,MPI_COMM_WORLD,ierr)
 
@@ -584,7 +584,7 @@
                  ta=5
                  call MPI_IRECV  (dom(ib)%recvb_p3(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%knext),dom(ib)%tg(ta),
-     &MPI_COMM_WORLD,dom(ib)%rq_p3,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_p3(1),ierr)
                  call MPI_SEND (dom(ib)%sendb_p3(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%knext),tag,MPI_COMM_WORLD,ierr)
 
@@ -624,7 +624,7 @@
                  tag=7*10**5+dom(ib)%corprev1
                call MPI_IRECV  (dom(ib)%rc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),dom(ib)%tg(8),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1m(1),ierr)
                  call MPI_SEND (dom(ib)%sc1m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev1),tag,MPI_COMM_WORLD,ierr)
   
@@ -659,7 +659,7 @@
                  tag=9*10**5+dom(ib)%corprev2
                  call MPI_IRECV  (dom(ib)%rc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),dom(ib)%tg(10),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2m(1),ierr)
                  call MPI_SEND (dom(ib)%sc2m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -694,7 +694,7 @@
                  tag=11*10**5+dom(ib)%corprev3
                  call MPI_IRECV  (dom(ib)%rc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),dom(ib)%tg(12),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3m(1),ierr)
                  call MPI_SEND (dom(ib)%sc3m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -729,7 +729,7 @@
                  tag=13*10**5+dom(ib)%corprev4
                 call MPI_IRECV  (dom(ib)%rc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),dom(ib)%tg(14),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4m(1),ierr)
                  call MPI_SEND (dom(ib)%sc4m(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%corprev4),tag,MPI_COMM_WORLD,ierr)
  
@@ -764,7 +764,7 @@
                  tag=8*10**5+dom(ib)%cornext1
                  call MPI_IRECV  (dom(ib)%rc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),dom(ib)%tg(7),
-     &MPI_COMM_WORLD,dom(ib)%rq_c1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c1p(1),ierr)
                  call MPI_SEND (dom(ib)%sc1p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -799,7 +799,7 @@
                  tag=10*10**5+dom(ib)%cornext2
                  call MPI_IRECV  (dom(ib)%rc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),dom(ib)%tg(9),
-     &MPI_COMM_WORLD,dom(ib)%rq_c2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c2p(1),ierr)
                  call MPI_SEND (dom(ib)%sc2p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext2),tag,MPI_COMM_WORLD,ierr)
 
@@ -834,7 +834,7 @@
                  tag=12*10**5+dom(ib)%cornext3
                  call MPI_IRECV  (dom(ib)%rc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),dom(ib)%tg(11),
-     &MPI_COMM_WORLD,dom(ib)%rq_c3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c3p(1),ierr)
                  call MPI_SEND (dom(ib)%sc3p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext3),tag,MPI_COMM_WORLD,ierr)
 
@@ -869,7 +869,7 @@
                  tag=14*10**5+dom(ib)%cornext4   
               call MPI_IRECV  (dom(ib)%rc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),dom(ib)%tg(13),
-     &MPI_COMM_WORLD,dom(ib)%rq_c4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_c4p(1),ierr)
                  call MPI_SEND (dom(ib)%sc4p(1),(pl+1)**3,MPI_FLT,
      &dom_ad(dom(ib)%cornext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -906,7 +906,7 @@
                  tag=15*10**5+dom(ib)%edgprev1
                  call MPI_IRECV  (dom(ib)%re1m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),dom(ib)%tg(16),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1m(1),ierr)
                  call MPI_SEND (dom(ib)%se1m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev1),tag,MPI_COMM_WORLD,ierr)
 
@@ -943,7 +943,7 @@
                  tag=17*10**5+dom(ib)%edgprev2
                  call MPI_IRECV  (dom(ib)%re2m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),dom(ib)%tg(18),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2m(1),ierr)
                  call MPI_SEND (dom(ib)%se2m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev2),tag,MPI_COMM_WORLD,ierr)
 
@@ -980,7 +980,7 @@
                  tag=19*10**5+dom(ib)%edgprev3
                  call MPI_IRECV  (dom(ib)%re3m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),dom(ib)%tg(20),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3m(1),ierr)
                  call MPI_SEND (dom(ib)%se3m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev3),tag,MPI_COMM_WORLD,ierr)
 
@@ -1017,7 +1017,7 @@
                  tag=21*10**5+dom(ib)%edgprev4
                  call MPI_IRECV  (dom(ib)%re4m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),dom(ib)%tg(22),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4m(1),ierr)
                  call MPI_SEND (dom(ib)%se4m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1054,7 +1054,7 @@
                  tag=23*10**5+dom(ib)%edgprev5
                  call MPI_IRECV  (dom(ib)%re5m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),dom(ib)%tg(24),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5m(1),ierr)
                  call MPI_SEND (dom(ib)%se5m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1091,7 +1091,7 @@
                  tag=25*10**5+dom(ib)%edgprev6
                  call MPI_IRECV  (dom(ib)%re6m(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),dom(ib)%tg(26),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6m,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6m(1),ierr)
                  call MPI_SEND (dom(ib)%se6m(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgprev6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1128,7 +1128,7 @@
                  tag=16*10**5+dom(ib)%edgnext1
                  call MPI_IRECV  (dom(ib)%re1p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),dom(ib)%tg(15),
-     &MPI_COMM_WORLD,dom(ib)%rq_e1p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e1p(1),ierr)
                  call MPI_SEND (dom(ib)%se1p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext1),tag,MPI_COMM_WORLD,ierr)
 
@@ -1165,7 +1165,7 @@
                  tag=18*10**5+dom(ib)%edgnext2
            call MPI_IRECV  (dom(ib)%re2p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),dom(ib)%tg(17),
-     &MPI_COMM_WORLD,dom(ib)%rq_e2p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e2p(1),ierr)
                  call MPI_SEND (dom(ib)%se2p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext2),tag,MPI_COMM_WORLD,ierr)
       
@@ -1202,7 +1202,7 @@
                  tag=20*10**5+dom(ib)%edgnext3
                  call MPI_IRECV  (dom(ib)%re3p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),dom(ib)%tg(19),
-     &MPI_COMM_WORLD,dom(ib)%rq_e3p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e3p(1),ierr)
                  call MPI_SEND (dom(ib)%se3p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext3),tag,MPI_COMM_WORLD,ierr)
 
@@ -1239,7 +1239,7 @@
                  tag=22*10**5+dom(ib)%edgnext4
                  call MPI_IRECV  (dom(ib)%re4p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),dom(ib)%tg(21),
-     &MPI_COMM_WORLD,dom(ib)%rq_e4p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e4p(1),ierr)
                  call MPI_SEND (dom(ib)%se4p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext4),tag,MPI_COMM_WORLD,ierr)
 
@@ -1276,7 +1276,7 @@
                  tag=24*10**5+dom(ib)%edgnext5
                  call MPI_IRECV  (dom(ib)%re5p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),dom(ib)%tg(23),
-     &MPI_COMM_WORLD,dom(ib)%rq_e5p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e5p(1),ierr)
                  call MPI_SEND (dom(ib)%se5p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext5),tag,MPI_COMM_WORLD,ierr)
 
@@ -1313,7 +1313,7 @@
                  tag=26*10**5+dom(ib)%edgnext6
                  call MPI_IRECV  (dom(ib)%re6p(1),trecv,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),dom(ib)%tg(25),
-     &MPI_COMM_WORLD,dom(ib)%rq_e6p,ierr)
+     &MPI_COMM_WORLD,dom(ib)%rq_e6p(1),ierr)
                  call MPI_SEND (dom(ib)%se6p(1),tsend,MPI_FLT,
      &dom_ad(dom(ib)%edgnext6),tag,MPI_COMM_WORLD,ierr)
 
@@ -1350,7 +1350,7 @@
         if (dom(ib)%corprev1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c1m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1365,7 +1365,7 @@
         if (dom(ib)%corprev2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c2m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1380,7 +1380,7 @@
         if (dom(ib)%corprev3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c3m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1395,7 +1395,7 @@
         if (dom(ib)%corprev4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%corprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%corprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c4m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
               do pl1=st1,pl; do pl2=st2,pl; do pl3=st3,pl
@@ -1410,7 +1410,7 @@
         if (dom(ib)%cornext1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext1)) then
-                 call MPI_WAIT(dom(ib)%rq_c1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c1p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
 !              if(LMR.eq.2 .and.
@@ -1427,7 +1427,7 @@
         if (dom(ib)%cornext2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext2)) then
-                 call MPI_WAIT(dom(ib)%rq_c2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c2p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
 !              if(LMR.eq.2 .and.
@@ -1444,7 +1444,7 @@
         if (dom(ib)%cornext3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext3)) then
-                 call MPI_WAIT(dom(ib)%rq_c3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c3p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
 !              if(LMR.eq.2 .and.
@@ -1461,7 +1461,7 @@
         if (dom(ib)%cornext4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%cornext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%cornext4)) then
-                 call MPI_WAIT(dom(ib)%rq_c4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_c4p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1; st3=1
 !              if(LMR.eq.2 .and.
@@ -1478,7 +1478,7 @@
         if (dom(ib)%edgprev1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e1m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1493,7 +1493,7 @@
         if (dom(ib)%edgprev2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e2m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1508,7 +1508,7 @@
         if (dom(ib)%edgprev3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e3m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=jspr,jepr
@@ -1523,7 +1523,7 @@
         if (dom(ib)%edgprev4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e4m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=ispr,iepr
@@ -1538,7 +1538,7 @@
         if (dom(ib)%edgprev5.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e5m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1553,7 +1553,7 @@
         if (dom(ib)%edgprev6.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgprev6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgprev6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6m,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e6m(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1568,7 +1568,7 @@
         if (dom(ib)%edgnext1.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext1)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext1)) then
-                 call MPI_WAIT(dom(ib)%rq_e1p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e1p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
 !              if(LMR.eq.2 .and.
@@ -1585,7 +1585,7 @@
         if (dom(ib)%edgnext2.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext2)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext2)) then
-                 call MPI_WAIT(dom(ib)%rq_e2p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e2p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
 !              if(LMR.eq.2 .and.
@@ -1602,7 +1602,7 @@
         if (dom(ib)%edgnext3.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext3)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext3)) then
-                 call MPI_WAIT(dom(ib)%rq_e3p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e3p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
 !              if(LMR.eq.2 .and.
@@ -1619,7 +1619,7 @@
         if (dom(ib)%edgnext4.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext4)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext4)) then
-                 call MPI_WAIT(dom(ib)%rq_e4p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e4p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
 !              if(LMR.eq.2 .and.
@@ -1636,7 +1636,7 @@
         if (dom(ib)%edgnext5.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext5)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext5)) then
-                 call MPI_WAIT(dom(ib)%rq_e5p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e5p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1651,7 +1651,7 @@
         if (dom(ib)%edgnext6.ge.0) then
            if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%edgnext6)) then
               if (dom_ad(dom_id(ib)).ne.dom_ad(dom(ib)%edgnext6)) then
-                 call MPI_WAIT(dom(ib)%rq_e6p,MPI_STATUS_IGNORE,ierr)
+                 call MPI_WAIT(dom(ib)%rq_e6p(1),MPI_STATUS_IGNORE,ierr)
               end if
               st1=1; st2=1
               do pl1=st1,pl; do pl2=st2,pl; do nn=kspr,kepr
@@ -1671,7 +1671,8 @@
               if (dom(ib)%iprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%iprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%iprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m1(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1690,7 +1691,8 @@
               if (dom(ib)%jprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%jprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m2(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1709,7 +1711,8 @@
               if (dom(ib)%kprev.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%kprev)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%kprev)) then
-                    call MPI_WAIT(dom(ib)%rq_m3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_m3(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1736,7 +1739,8 @@
               if (dom(ib)%inext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%inext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%inext)) then
-                    call MPI_WAIT(dom(ib)%rq_p1,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p1(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1755,7 +1759,8 @@
               if (dom(ib)%jnext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%jnext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%jnext)) then
-                    call MPI_WAIT(dom(ib)%rq_p2,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p2(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl
@@ -1774,7 +1779,8 @@
               if (dom(ib)%knext.ge.0)  then
               if(rdiv(dom_id(ib)).ne.rdiv(dom(ib)%knext)) then
                  if (dom_ad(dom_id(ib)) .ne. dom_ad(dom(ib)%knext)) then
-                    call MPI_WAIT(dom(ib)%rq_p3,MPI_STATUS_IGNORE,ierr)
+                    call MPI_WAIT(dom(ib)%rq_p3(1),MPI_STATUS_IGNORE,
+     &ierr)
                  end if
                  ispr=pl+1;	jspr=pl+1;	kspr=pl+1
                  iepr=ni-pl;	jepr=nj-pl;	kepr=nk-pl

--- a/source/module_multidata.for
+++ b/source/module_multidata.for
@@ -28,11 +28,13 @@
 	   integer :: isw,iew,jsw,jew,ksw,kew
            integer :: nwork,nvars
            integer :: mximb
-           integer :: rq_m1,rq_p1,rq_m2,rq_p2,rq_m3,rq_p3
-           integer :: rq_c1m,rq_c2m,rq_c3m,rq_c4m
-           integer :: rq_c1p,rq_c2p,rq_c3p,rq_c4p
-           integer :: rq_e1m,rq_e2m,rq_e3m,rq_e4m,rq_e5m,rq_e6m
-           integer :: rq_e1p,rq_e2p,rq_e3p,rq_e4p,rq_e5p,rq_e6p
+           integer, dimension(2) :: rq_m1,rq_p1,rq_m2,rq_p2,rq_m3,rq_p3
+           integer, dimension(2) :: rq_c1m,rq_c2m,rq_c3m,rq_c4m
+           integer, dimension(2) :: rq_c1p,rq_c2p,rq_c3p,rq_c4p
+           integer, dimension(2) :: rq_e1m,rq_e2m,rq_e3m,rq_e4m,rq_e5m,
+     &rq_e6m
+           integer, dimension(2) :: rq_e1p,rq_e2p,rq_e3p,rq_e4p,rq_e5p,
+     &rq_e6p
            double precision    :: xsl,ysl,zsl,xel,yel,zel,dx,dy,dz
 	     double precision,pointer,dimension(:) :: tauw
            double precision, pointer, dimension(:,:,:) :: S,So,Sm,Stm

--- a/source/module_multidata.for
+++ b/source/module_multidata.for
@@ -28,6 +28,8 @@
 	   integer :: isw,iew,jsw,jew,ksw,kew
            integer :: nwork,nvars
            integer :: mximb
+           ! These rq_* variables are MPI requests.
+           ! The 1st value is used to track receives and the 2nd sends.
            integer, dimension(2) :: rq_m1,rq_p1,rq_m2,rq_p2,rq_m3,rq_p3
            integer, dimension(2) :: rq_c1m,rq_c2m,rq_c3m,rq_c4m
            integer, dimension(2) :: rq_c1p,rq_c2p,rq_c3p,rq_c4p


### PR DESCRIPTION
The current ghost-cell exchange code deadlocks when run with Cray-MPICH. This is because we currently rely on the`MPI_IRECV() - MPI_SEND()` pattern to be non-blocking. Unfortunately, this assumption does not hold on systems which implement the send via a rendez-vous protocol rather than an eager protocol. For example, on the Met Office XC40 system the code deadlocks with different MPI tasks waiting on  each other to send data- see the output from a debugger below
![T4_deadlock](https://user-images.githubusercontent.com/39091922/84139356-9d7f7f80-aa47-11ea-9104-c6bf3f446e50.png)

In order to avoid this issue in our test case we implement a `MPI_IRECV()-MPI_ISEND()-MPI_WAITALL()` pattern for the `exchange_smlvl()` subroutine. Note that we have not (yet) changed the communications used in simulations which use LMR .

A version of these changes has been tested on the Cray XC40 machine mentioned above (though these tests include other fixes which will be ported in a separate PR). We have also run the Cavity Flow benchmark example included in the repo with the core code plus the changes in this PR on a separate linux cluster.
