### PR TITLE
compile-time issues identified using the GNU and NAG compilers

### DIFF
--- a/source/DeltaF_MLS.for
+++ b/source/DeltaF_MLS.for
@@ -462,12 +462,12 @@
 !######################################################################
         use mpi
 	implicit none
+        INTEGER, intent(in):: neignum,MAXNEIG
 	Double precision, intent(in) :: hx,hy,hz,kwx1,kwx2,kwy1
 	Double precision, intent(in) :: kwy2,kwz1,kwz2
 	Double precision, intent(in) :: difx(MAXNEIG)
 	Double precision, intent(in) ::dify(MAXNEIG)
 	Double precision, intent(in) :: difz(MAXNEIG)
-	INTEGER, intent(in):: neignum,MAXNEIG
         INTEGER :: I,J
         Double precision:: cero, coef,cx1,cx2,cy1,cy2,cz1,cz2,PI
         Double precision:: dmx,dmy,dmz,Wx,Wy,Wz,dWx,dWy,dWz

--- a/source/LPT.for
+++ b/source/LPT.for
@@ -453,7 +453,7 @@
 !	Fpv(l) = -(Fav(l) + Fdv(l) + Flv(l))
 !	Fpw(l) = -(Faw(l) + Fdw(l) + Flw(l))
 
-	if (DF.eq..false.) then
+	if (.NOT. DF) then
 
       Fpu(l) = -(3.0d0*((ui_pt(l)-uoi_pt(l))/dt)	
      &  -(3.0d0/(2.0d0*dp_loc(l)))*Cd*sqrt(a**2.d0+b**2.d0+c**2.d0)*a  
@@ -479,7 +479,7 @@
 !     	write(myrank+700,*)'Fp',Fpu(l),Fpv(l),Fpw(l)
 
 !$OMP CRITICAL
-	if (PSIcell.eq..true.) then
+	if (PSIcell) then
 
            	dom(ib)%ustar(ipu(l),jp(l),kp(l)) = 
      &	dom(ib)%ustar(ipu(l),jp(l),kp(l)) + dt * alfapr * Fpu(l) *

--- a/source/actuator.for
+++ b/source/actuator.for
@@ -155,7 +155,7 @@
          gridfile='geom_ActL_'//TRIM(ADJUSTL(char_block))//'.dat'
          open (unit=2, file=gridfile)
 !----      Load the file and proceed to interpolate     ----------
- 	open(unit=1, name=filepoints(numIB))
+ 	open(unit=1, file=filepoints(numIB))
 	   read(1,*)n_act
 	   read(1,*)
 	   allocate(r_in(n_act),c_in(n_act),Pit_in(n_act))

--- a/source/alloc_pt.for
+++ b/source/alloc_pt.for
@@ -53,7 +53,7 @@
 
 50	continue
 
-		if (out_pt(l).eq..false.) then
+		if (.NOT. out_pt(l)) then
       		xpold(l-out_cnt)=xp_pt(l)
            		ypold(l-out_cnt)=yp_pt(l)
            		zpold(l-out_cnt)=zp_pt(l)

--- a/source/averaging.for
+++ b/source/averaging.for
@@ -158,7 +158,7 @@
                   dom(ib)%Ttm(i,j,k)=dom(ib)%facm2(i,j,k)*
      & dom(ib)%Ttm(i,j,k)+dom(ib)%facp2(i,j,k)*TfTf
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1
-	IF(LSCALAR.EQ..TRUE.) THEN
+	IF(LSCALAR) THEN
                   dom(ib)%Sm(i,j,k)=dom(ib)%facm1(i,j,k)*
      & dom(ib)%Sm(i,j,k)+dom(ib)%facp1(i,j,k)*dom(ib)%S(i,j,k)
                   SfSf=(dom(ib)%S(i,j,k)-dom(ib)%Sm(i,j,k))*
@@ -196,7 +196,7 @@
      & dom(ib)%Ttm(i,j,k)+dom(ib)%facp2(i,j,k)*TfTf
 
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!1
-	IF(LSCALAR.EQ..TRUE.) THEN
+	IF(LSCALAR) THEN
                   dom(ib)%Sm(i,j,k)=dom(ib)%facm1(i,j,k)*
      & dom(ib)%Sm(i,j,k)+dom(ib)%facp1(i,j,k)*dom(ib)%S(i,j,k)
                   SfSf=(dom(ib)%S(i,j,k)-dom(ib)%Sm(i,j,k))*

--- a/source/checkdt.for
+++ b/source/checkdt.for
@@ -135,7 +135,7 @@
 
         dt=dt1
 
-	  if (variTS.eq. .true.) dt=dtinit
+	  if (variTS) dt=dtinit
 
        dtsum=dtsum+dt
 

--- a/source/flosol.for
+++ b/source/flosol.for
@@ -29,7 +29,7 @@
         alfabc = 1
         alfapr = 1.0
 
-        if (LRESTART.eq..false.) cnt_pt = 1 
+        if (.NOT. LRESTART) cnt_pt = 1 
 
         numfile1=1002; numfile2=1003; numfile3=1004
 	  numfile4=1005; numfile5=1006
@@ -75,7 +75,7 @@
            ctime=ctime+dt  ;  ntime = ntime + 1
 
 !Reading inflow data, bc_west = 7
-	   if (read_inflow.eq..true.) then  
+	   if (read_inflow) then  
            		if (ireadinlet.eq.ITMAX_PI.and.iaddinlet.eq.1) then
 				iaddinlet=-1
           		elseif (ireadinlet.eq.1.and.iaddinlet.eq.-1) then
@@ -227,28 +227,28 @@
 	  if (ctime.ge.t_start_averaging1) call timesig				
 
 !Write outflow planes
-	  if ((save_inflow.eq..true.) .and. itime.ge.itime_start)
+	  if ((save_inflow) .and. itime.ge.itime_start)
      &     call write_inflow		       !set itime since when you'd like to write inflow planes
 	 
 !Write results in tecplot format 
        IF ((mod(itime,n_out).eq.0).and.(itime.ge.itime_start)) then
-	  	  IF (LTURB.EQ..TRUE.)     call tec_turb(itime)
-	  	  IF (LINST.EQ..TRUE.)     call tec_instant(itime)
-	 	  IF (LPLAN.EQ..TRUE.)     call tec_inst_plane(itime)
-	 	  IF (LTECP.EQ..TRUE.)     call tecplot_p(itime)
-	  	  IF (LTECBIN.EQ..TRUE.)   call tecbin(itime)
-		  IF (L_LSM.EQ..TRUE.)     call tecplot_phi(itime)
-		  IF (L_LSMbase.EQ..TRUE.) call tecplot_phi(itime)	!!
-	 	  IF (LENERGY.EQ..TRUE.)   call tecplot_T(itime)	!!
-	 	  IF (LSCALAR.EQ..TRUE.)   call tecplot_S(itime)	!!
+	  	  IF (LTURB)     call tec_turb(itime)
+	  	  IF (LINST)     call tec_instant(itime)
+	 	  IF (LPLAN)     call tec_inst_plane(itime)
+	 	  IF (LTECP)     call tecplot_p(itime)
+	  	  IF (LTECBIN)   call tecbin(itime)
+		  IF (L_LSM)     call tecplot_phi(itime)
+		  IF (L_LSMbase) call tecplot_phi(itime)	!!
+	 	  IF (LENERGY)   call tecplot_T(itime)	!!
+	 	  IF (LSCALAR)   call tecplot_S(itime)	!!
 !File containing information needed for restarting
-	  	  IF (LTECBIN.EQ..TRUE.)   then
+	  	  IF (LTECBIN)   then
          open (unit=101, file='final_ctime.dat')
          IF(myrank.eq.0) write(101,'(i8,3F15.6)')ntime,ctime,forcn,qstpn
          close(101)
 		  ENDIF
 !Lagrangian Particle Tracking final checks
-	       if (LPT.eq..TRUE. .AND. myrank.eq.0) then          			
+	       if (LPT .AND. myrank.eq.0) then          			
 	    		open(30,file='final_particle.dat')
 	   	 	write(30,*) np
 	    		write(30,*) cnt_pt
@@ -303,12 +303,12 @@
 	  close(203) !worktime.dat
 !Output final results:
         if (mod(itime,n_out).ne.0) then
-	  	  IF (LTURB.EQ..TRUE.)   call tec_turb(itime)
-	  	  IF (LTECBIN.EQ..TRUE.) call tecbin(itime)
-		  IF (L_LSM.EQ..TRUE.)   call tecplot_phi(itime)
-		  IF (L_LSMbase.EQ..TRUE.)   call tecplot_phi(itime)	!!
-	 	  IF (LENERGY.EQ..TRUE.)   call tecplot_T(itime)	!!
-	 	  IF (LSCALAR.EQ..TRUE.)   call tecplot_S(itime)	!!
+	  	  IF (LTURB)   call tec_turb(itime)
+	  	  IF (LTECBIN) call tecbin(itime)
+		  IF (L_LSM)   call tecplot_phi(itime)
+		  IF (L_LSMbase)   call tecplot_phi(itime)	!!
+	 	  IF (LENERGY)   call tecplot_T(itime)	!!
+	 	  IF (LSCALAR)   call tecplot_S(itime)	!!
 		  if (ctime.ge.t_start_averaging2)  call timesig
            open (unit=101, file='final_ctime.dat')
            if(myrank.eq.0) write (101,'(i8,3F15.6)') 

--- a/source/ibm.for
+++ b/source/ibm.for
@@ -72,7 +72,7 @@
 		read (1,*) imbnumber(M)
 		read (1,*) radsin(M)		
 
-	   if(ibturbine(M).EQ..FALSE.) then
+	   if(.NOT. ibturbine(M)) then
 	    xaero(M)=0.d0 ; yaero(M)=0.d0 ; zaero(M)=0.d0 	
 	    pitch(M)=0.d0 ; turax(M)=1    ; imbnumber(M)=1
 	    LSELFST(M)=.false.
@@ -81,11 +81,11 @@
 	    xaero(M)=0.d0 ; yaero(M)=0.d0 ; zaero(M)=0.d0 		
 	    pitch(M)=0.d0 ; imbnumber(M)=1 ; LSELFST(M)=.false.	
 	   endif
-	   if (rotating(M).eq..FALSE.) radsin(M)=0.d0
-	   if (LSELFST(M).eq..TRUE.) radsin(M)=0.d0
+	   if (.NOT. rotating(M)) radsin(M)=0.d0
+	   if (LSELFST(M)) radsin(M)=0.d0
 
 !Actuator line:
-	   if(ibturbine(M).EQ..true. .and. turax(M).eq.3 .and. M.eq.1) then
+	   if(ibturbine(M) .and. turax(M).eq.3 .and. M.eq.1) then
 	    allocate(r_act(5000),c_act(5000),Pit_act(5000))
 	    r_act=0.d0 ; c_act=0.d0 ;Pit_act=0.d0 
 	   endif
@@ -154,7 +154,7 @@
 	DO M=1,bodynum
 	 DO i=1,imbnumber(M)
              L=L+1 ; forcefilej=399+L
-	 IF (ibturbine(M).eq..true.) then !Rotating VATT
+	 IF (ibturbine(M)) then !Rotating VATT
          write(char_block,'(i2)') L
          strlen=LEN(TRIM(ADJUSTL(char_block)))
          char_block=REPEAT('0',(2-strlen))//TRIM(ADJUSTL(char_block))
@@ -184,7 +184,7 @@
 	write(6,'(a,f12.4,a)')'     Angle step : ',anst,'deg/iteration'
 	    ENDIF
 	  ENDIF
-	 IF(LSELFST(M).eq..true.) then
+	 IF(LSELFST(M)) then
 	   forcefilej=5452+M
          write(char_block,'(i2)') M
          strlen=LEN(TRIM(ADJUSTL(char_block)))
@@ -196,7 +196,7 @@
 	 ENDIF !TURBINE
 363	CONTINUE	!09-2017
 
-	 IF (ibturbine(M).eq..false. .and. rotating(L).eq..false. ) then !Rotating VATT
+	 IF ((.NOT. ibturbine(M)) .and. (.NOT. rotating(L))) then !Rotating VATT
          write(char_block,'(i2)') L
          strlen=LEN(TRIM(ADJUSTL(char_block)))
          char_block=REPEAT('0',(2-strlen))//TRIM(ADJUSTL(char_block))
@@ -212,7 +212,7 @@
          if(imb_shape(M).eq.4) then
          gridfile='F_Sph_'//TRIM(ADJUSTL(char_block))//'.dat'
      	 endif     
-         if(imb_shape(M).eq.5 .and. rotating(L).eq..false.) then
+         if(imb_shape(M).eq.5 .and. (.NOT. rotating(L))) then
          gridfile='F_Bod_'//TRIM(ADJUSTL(char_block))//'.dat'
      	 endif 	      
          if(imb_shape(M).ge.11) then
@@ -222,8 +222,8 @@
            write (forcefilej,*)'Variables=CTIME,Fx,Fy,Fz'
 	 ENDIF
 
-        if(imb_shape(M).eq.5 .and. ibturbine(M).eq..false.) then
-	   if(rotating(L).eq..true.) then
+        if(imb_shape(M).eq.5 .and. (.NOT. ibturbine(M))) then
+	   if(rotating(L)) then
            write(char_block,'(i2)') L
            strlen=LEN(TRIM(ADJUSTL(char_block)))
            char_block=REPEAT('0',(2-strlen))//TRIM(ADJUSTL(char_block))
@@ -275,7 +275,7 @@
          open (unit=2, file=gridfile)
 	write(2,*)'variables=x,y,z,al0,R0'
 
-	 if(ibturbine(M).eq..false.) then  !Not a turbine
+	 if(.NOT. ibturbine(M)) then  !Not a turbine
 
            do L=1,nodes(M)    			!!!!!assumed z-axis...
             alpha0(M,L)=datan(nodexlocal(M,L)/nodeylocal(M,L))
@@ -459,8 +459,8 @@
 	     CALL ActuatorLine_Initial			!Turbine via Actuator Line model
 	endif
 
-	 IF (imb_shape(K).eq.5 .and. rotating(K).eq..TRUE.) then
-	   if(ibturbine(K).eq..true.) then
+	 IF (imb_shape(K).eq.5 .and. rotating(K)) then
+	   if(ibturbine(K)) then
 	      IF(LSELFST(K)) then  				!Self-starting 07_2017
 			call move_ST 
 		ELSE
@@ -470,7 +470,7 @@
        	rads(K)=-radsin(K)*3.1416D0/180.D0*DSIN(0.1983*CTIME)	!Pitching airfoil case
 	   endif
 		 call imb_moved(K) 		 		!In shapes.for
-	   if(ibturbine(K).eq..true. .and. turax(K).eq.1)
+	   if(ibturbine(K) .and. turax(K).eq.1)
      &	 call imb_moved_shades(K)  			 !In shapes.for
 	 ENDIF
 	Enddo	
@@ -507,7 +507,7 @@
 !		call imb_averaging !Calculate mean IB force values
 	if (mod(itime,2) .eq. 0 .and. ibm_out_forces.eq.1) then
 		call caldrag	!Output of IB forces
-		if(ibturbine(1).eq. .TRUE. .and. turax(1).eq.2) then
+		if(ibturbine(1) .and. turax(1).eq.2) then
 		 call imb_FEM		!Structural loadings of all blades
 		 call imb_FEM_oneblade !Structural loadings for a single blade divided into sections
 	      endif
@@ -608,7 +608,7 @@
 		R0_loc(ii)=R0(M,L) ; alpha0_loc(ii)=alpha0(M,L)
 	     ENDIF 
 		rott_loc(ii)=1 	!Moving Lagrangian
-		IF(rotating(M).eq..false.)rott_loc(ii)=2  	!Static Lagrangian
+		IF(.NOT. rotating(M))rott_loc(ii)=2  	!Static Lagrangian
 	  ENDDO
 	 Enddo
 	ENDIF !master
@@ -984,7 +984,7 @@
  	  IF (imb_shape(M).eq.5 .and. turax(M).eq.3) THEN	!Pablo 09/2017
 		call ActuatorLine(M,L,ib)
 	  ELSE
-	   IF(ibturbine(M).eq..TRUE.) then 			!If it is a turbine
+	   IF(ibturbine(M)) then 			!If it is a turbine
 	    IF (turax(M).eq.1) then			! Vertical Axis Turbine
 	      UIB_loc=-radsin(M)*R0_loc(L)*dcos(rads(M)+alpha0_loc(L))
 	      VIB_loc=-radsin(M)*R0_loc(L)*dsin(rads(M)+alpha0_loc(L))
@@ -996,8 +996,8 @@
 	      WIB_loc=-radsin(M)*R0_loc(L)*dsin(rads(M)+alpha0_loc(L))
 	    ENDIF	     
 	   ENDIF
-	    IF (ibturbine(M).eq..FALSE. .AND. imb_shape(M).eq.5
-     &			.and. rotating(M).eq..true.) then	! from file but moving
+	    IF ((.NOT. ibturbine(M)) .AND. imb_shape(M).eq.5
+     &			.and. rotating(M)) then	! from file but moving
 !	      UIB_loc=-radsin(M)*R0_loc(L)*dcos(rads(M)+alpha0_loc(L)) !Pitching airfoil simu
 !	      VIB_loc=-radsin(M)*R0_loc(L)*dsin(rads(M)+alpha0_loc(L))
 !	      WIB_loc= 0.d0	
@@ -1111,7 +1111,7 @@
 
 	J=0
 	Do M = 1,bodynum
-	IF (imb_shape(M).eq.5 .and. rotating(M).eq..true.) then
+	IF (imb_shape(M).eq.5 .and. rotating(M)) then
 	  Do iii=1,imbnumber(M)
 		J=J+1 ; forcefilej=399+J    
  	  fx_loc = 0.d0   ; fy_loc = 0.d0 ; fz_loc = 0.d0 
@@ -1154,7 +1154,7 @@
      &	/dt*dxm*dym*dzm
 	 end do
 
-	If(LSELFST(M).eq..true.) SUMtorque_ST(M) = SUMtorque_ST(M)+ ft_loc !Self-starting 07_2017
+	If(LSELFST(M)) SUMtorque_ST(M) = SUMtorque_ST(M)+ ft_loc !Self-starting 07_2017
 
          write(forcefilej,88)alpharads,fx_loc,fy_loc
      &	,ft_loc,ft2_loc,fn_loc,fn2_loc,M_loc
@@ -1233,7 +1233,7 @@
 
 	Do M=1,bodynum
 	
-	IF (rotating(M).eq..TRUE.) then
+	IF (rotating(M)) then
          write(ibnum,'(I2)') M
            strlen2=LEN(TRIM(ADJUSTL(ibnum)))
            ibnum=REPEAT('0',(2-strlen2))//TRIM(ADJUSTL(ibnum))

--- a/source/init_particle.for
+++ b/source/init_particle.for
@@ -82,7 +82,7 @@ C#############################################################
             end do
 	enddo
 
-       elseif (LRESTART.eq..false.) then
+       elseif (.NOT. LRESTART) then
 	  	write(202,*) 'First release:',np,'new particles. Total:',np
 
 		if (random) then

--- a/source/initial.for
+++ b/source/initial.for
@@ -150,7 +150,7 @@
 	   stop
 	  endif
 
-	  if (L_anim_phi .and. L_LSM.eq..FALSE.) then
+	  if (L_anim_phi .and. (.NOT. L_LSM)) then
 	   if (myrank.eq.0) then
           print*,'Error: L_anim_phi cannot be true if L_LSM is false!'
 	   endif
@@ -748,7 +748,7 @@
                read (700,'(i8,3F18.12)') ntime,ctime,forcn,qstpn
               close (700)
 
-	     if(pressureforce_y .eq. .true.) then				!PABLO 12/18
+	     if(pressureforce_y) then				!PABLO 12/18
               open (unit=700, file='forcn_y.dat')
 	       read (700,*) 
 		   do i=1,ntime
@@ -758,7 +758,7 @@
               close (700)
 		    endif
 
-	     if(pressureforce_z .eq. .true.) then
+	     if(pressureforce_z) then
               open (unit=700, file='forcn_z.dat')
 		    do i=1,ntime
                  read (700,'(4F18.12)',END=201) dum,forcn_z,qstpn_z,dum
@@ -816,7 +816,7 @@
               end do
               close (700)
 
-		IF (LENERGY.EQ..TRUE. )then
+		IF (LENERGY)then
               gf='tecplot_T'//trim(adjustl(chb1))//'.plt'
               open (unit=700, file=gf,status='old')
               read (700) 
@@ -833,7 +833,7 @@
               end do
               close (700)
 		ENDIF
-		IF (LSCALAR.EQ..TRUE. )then
+		IF (LSCALAR)then
               gf='tecplot_S'//trim(adjustl(chb1))//'.plt'
               open (unit=700, file=gf,status='old')
               read (700) 

--- a/source/lsm.for
+++ b/source/lsm.for
@@ -498,7 +498,7 @@
       bool=.false.
       it=0
 
-      do while (bool.eq..false.)
+      do while (.NOT. bool)
 !
 ! 1st step
 !     

--- a/source/newsolv_mg.for
+++ b/source/newsolv_mg.for
@@ -58,12 +58,12 @@
         end do
 
         if (myrank.eq.0) print*,'not converged!! ',maxcy,rmax
-        if (myrank.eq.0) write(numfile,*),'not converged!! ',maxcy,rmax
+        if (myrank.eq.0) write(numfile,*) 'not converged!! ',maxcy,rmax
  3000   continue
 
         if(rmax.gt.10.0) then
            if(myrank.eq.0) then
-		 write(numfile,*),'BIG RMAX!! STOP!!!!!',rmax
+		 write(numfile,*) 'BIG RMAX!! STOP!!!!!',rmax
              open (unit=101, file='final_ctime.dat')
                write (101,'(i8,3F15.6)') ntime,ctime,forcn,qstpn
              close(101)

--- a/source/post.for
+++ b/source/post.for
@@ -169,7 +169,7 @@
 	  itotk=1 	; ntotk=totk/itotk+1
 
 
-	IF(L_LSM.EQ..FALSE.) THEN
+	IF(.NOT. L_LSM) THEN
         write (88,*) 'title = turb'
         write (88,*)'variables=x,y,z,U,V,W,UM,VM,WM'
 !     &, ,'uuM,vvM,wwM,uvM,uwM,vwM'
@@ -232,7 +232,7 @@
      &dom(ib)%vwm(i+1,j,k+1)  +dom(ib)%vwm(i,j+1,k+1)+
      &dom(ib)%vwm(i+1,j+1,k+1))
 
-	IF(L_LSM.EQ..FALSE.) THEN
+	IF(.NOT. L_LSM) THEN
           write (88,88) dom(ib)%x(i),dom(ib)%y(j),
      &  dom(ib)%z(k),u_cn,v_cn,w_cn,um_cn,vm_cn,wm_cn
 !     &  ,uum_cn,vvm_cn,wwm_cn,uvml,uwml,vwml

--- a/source/press.for
+++ b/source/press.for
@@ -228,7 +228,7 @@
            jspr=pl+1; jepr=dom(ib)%ttc_j-pl
            kspr=pl+1; kepr=dom(ib)%ttc_k-pl
 
-	if(pressureforce  .eq. .true.) then
+	if(pressureforce) then
            if(dom(ib)%iprev.lt.0) then						!west
               do j=jspr,jepr
                  do k=kspr,kepr
@@ -257,7 +257,7 @@
            end if
 	endif
 
-	if(pressureforce_y .eq. .true.) then
+	if(pressureforce_y) then
            if(dom(ib)%jprev.lt.0) then
               do i=ispr,iepr
                  do k=kspr,kepr
@@ -286,7 +286,7 @@
            end if
 	endif
 
-	if(pressureforce_z  .eq. .true.) then
+	if(pressureforce_z) then
            if(dom(ib)%kprev.lt.0) then
               do i=ispr,iepr
                  do j=jspr,jepr
@@ -317,21 +317,21 @@
         end do
 
 !.....sum massflux and area over all processors
-	if(pressureforce .eq. .true.) then
+	if(pressureforce) then
         sndbuffer(1)   = flwsum_loc    ;  sndbuffer(2)   = A_loc
         call MPI_ALLREDUCE(sndbuffer,recbuffer,2,
      &                   MPI_FLT,MPI_SUM,MPI_COMM_WORLD,ierr)
         flwsum   = recbuffer(1)  ;   A        = recbuffer(2)
 	endif
 
-	if(pressureforce_y .eq. .true.) then
+	if(pressureforce_y) then
         sndbuffer_y(1) = flwsum_loc_y  ;  sndbuffer_y(2) = A_loc_y
         call MPI_ALLREDUCE(sndbuffer_y,recbuffer_y,2,
      &                   MPI_FLT,MPI_SUM,MPI_COMM_WORLD,ierr)
         flwsum_y = recbuffer_y(1)  ;   A_y    = recbuffer_y(2)
 	endif
 
-	if(pressureforce_z .eq. .true.) then
+	if(pressureforce_z) then
         sndbuffer_z(1) = flwsum_loc_z  ;  sndbuffer_z(2) = A_loc_z
         call MPI_ALLREDUCE(sndbuffer_z,recbuffer_z,2,
      &                   MPI_FLT,MPI_SUM,MPI_COMM_WORLD,ierr)
@@ -340,36 +340,36 @@
 
 ! --- Calculate and store forcing term --------------------------------
         fakfor  = 0.3
-	 if(pressureforce .eq. .true.)    qstpp   = flwsum/A
-	 if(pressureforce_y .eq. .true.)  qstpp_y = flwsum_y/A_y
-	 if(pressureforce_z .eq. .true.)  qstpp_z = flwsum_z/A_z
+	 if(pressureforce)    qstpp   = flwsum/A
+	 if(pressureforce_y)  qstpp_y = flwsum_y/A_y
+	 if(pressureforce_z)  qstpp_z = flwsum_z/A_z
 
 ! Whatever the flow is lost, is added back again
 ! 	  Q(t)=Q(t-1)+0.3?  *(U(0) +U(t-1)-2*U(t))/dt
-	 if(pressureforce .eq. .true.)  then
+	 if(pressureforce)  then
         forcn=forcn+fakfor*(qzero+qstpn-2.0*qstpp)/dt
         qstpn = qstpp
 	 endif
 
-	 if(pressureforce_y .eq. .true.)  then
+	 if(pressureforce_y)  then
         forcn_y=forcn_y+fakfor*(0.0+qstpn_y-2.0*qstpp_y)/dt
         qstpn_y = qstpp_y
 	 endif
 
-	 if(pressureforce_z .eq. .true.)  then
+	 if(pressureforce_z)  then
         forcn_z=forcn_z+fakfor*(0.0+qstpn_z-2.0*qstpp_z)/dt
         qstpn_z = qstpp_z
 	 endif
 
 !Write out values in the 3 directions:
         if(myrank.eq.0) then
-	 if(pressureforce .eq. .true.)  
+	 if(pressureforce)  
      & 	write (numfile1,'(4F18.12)') ctime,forcn,qstpn,flwsum
 
-	 if(pressureforce_y .eq. .true.)  
+	 if(pressureforce_y)  
      & 	write (numfile4,'(4F18.12)') ctime,forcn_y,qstpn_y,flwsum_y
 
-	 if(pressureforce_z .eq. .true.)  
+	 if(pressureforce_z)  
      & 	write (numfile5,'(4F18.12)') ctime,forcn_z,qstpn_z,flwsum_z
 	 endif
 
@@ -480,8 +480,8 @@
  3000   continue
 
         if(rmax.gt.10.d0) then
-           if(myrank.eq.0) write(numfile,*),'BIG RMAX!! STOP!!!!!',rmax
-           write(6,*),'BIG RMAX!! STOP!!!!!!!!',rmax
+           if(myrank.eq.0) write(numfile,*) 'BIG RMAX!! STOP!!!!!',rmax
+           write(6,*) 'BIG RMAX!! STOP!!!!!!!!',rmax
 
            if(myrank.eq.0) then
               open (unit=101, file='final_ctime.dat')

--- a/source/shapes.for
+++ b/source/shapes.for
@@ -829,9 +829,12 @@
          gridfile='geom_body_'//TRIM(ADJUSTL(char_block2))//'.dat'
          open (unit=2, file=gridfile)
 !----      Load the file and proceed to interpolate     ----------
- 	open(unit=1, name=filepoints(numIB))
-	if (ibturbine(numIB).eq..true.)read(1,*)nin,nscatter(numIB)	!Mesh points	
-	if (ibturbine(numIB).eq..false.)read(1,*)nin	!Mesh points	
+ 	open(unit=1, file=filepoints(numIB))
+	if (ibturbine(numIB)) then
+           read(1,*)nin,nscatter(numIB)	!Mesh points
+        else
+           read(1,*)nin         !Mesh points
+        end if
 
 	select case(axis(numIB))			!Brunho2015
 	CASE (1) !-------------------------------------------
@@ -932,7 +935,7 @@
    		ENDDO
 	end select
  !--------Local and global coordinates  --------------------------------
-	IF (ibturbine(numIB).eq..true.) then	!if body is a turbine 
+	IF (ibturbine(numIB)) then	!if body is a turbine 
 	   an=pitch(numIB)*PI/180.d0	   !Angle of attack in radians
 	   do i=1,nin*nlay		   !Rotate the body.
 	    nodex(numIB,i)=nodex(numIB,i)-xaero(numIB)
@@ -1131,7 +1134,7 @@
  	endif
 
 !- Distinguish between turbines (HA and VA) and non-turbines --------------
-	IF (ibturbine(numIB) 	.eq..true.) then		! Turbine
+	IF (ibturbine(numIB)) then		! Turbine
 !-------------------------------------------------------------------	
 	IF (turax(numIB).eq.1) then	! Vertical Axis 
        do L=1,nodes(numIB)
@@ -1168,7 +1171,7 @@
 	ENDIF !Turbine
 !--------------------------------------------------
 !_----- NON-TURBINE BODY which is moving   ------- 
-       IF (ibturbine(numIB) .eq. .false.) then		! Non-Turbine
+       IF (.NOT. ibturbine(numIB)) then		! Non-Turbine
 	do L=1,nodes(numIB)
 	 nodex(numIB,L)=
      &   R0(numIB,L)*DSIN(rads(numIB)+alpha0(numIB,L))+Cxor(numIB)
@@ -1211,7 +1214,7 @@
 
       IF (myrank.ne.master) goto 797
 
-	IF (ibturbine(numIB).ne..true. .and. turax(numIB).ne.1) RETURN !Only works for VAT
+	IF ((.NOT. ibturbine(numIB)) .and. turax(numIB).ne.1) RETURN !Only works for VAT
 	 	K=nodes(numIB)/imbnumber(numIB) 	! Vertical Axis Turbine
          GT1=301  
          write(char_block,'(I8)') itime


### PR DESCRIPTION
In order to improve the portability of the codebase we address four syntactic issues identified when building the model with gfortran and nagfor. None of these changes in this PR should alter model output, they are simply changes to the syntax used in the code.
* The use of `.EQ.` and `.NEQ.` operators on logical variables is not permitted in the fortran standard. The Intel compiler lets us get away with it but other compilers implement the standard more strictly. Doctor Fortran explains some of the reasoning behind the `.EQ.` vs `.EQV.` issue [here](https://software.intel.com/en-us/forums/intel-fortran-compiler/topic/275071#comment-1548435).
* The `name=` keyword in `OPEN()` statements is an [Intel-specific extension](https://software.intel.com/content/www/us/en/develop/documentation/fortran-compiler-developer-guide-and-reference/top/compiler-reference/data-and-i-o/fortran-i-o/opening-files-open-statement.html). The portable version of this is `file=`.
* `WRITE()` statements shouldn't have a `,` immediately after them.
* In subroutines in which fixed sized arrays, say `A(N)` and `B(N)`, and the size of the fixed arrays, `N`, are passed as dummy arguments the size should be declared before the arrays. 

These changes compile with ifort and almost allow a gfortran build to complete (requires changes in a future PR). We have tested this branch with the Cavity Flow benchmark.